### PR TITLE
Add dein#is_sourced() function

### DIFF
--- a/autoload/dein.vim
+++ b/autoload/dein.vim
@@ -255,6 +255,10 @@ function! dein#tap(name) abort "{{{
         \ && isdirectory(g:dein#_plugins[a:name].path)
 endfunction"}}}
 
+function! dein#is_sourced(name) abort "{{{
+  return dein#tap(a:name) && dein#get(a:name).sourced
+endfunction"}}}
+
 function! dein#save_cache() abort "{{{
   if dein#_get_base_path() == '' || !exists('s:vimrcs')
     " Ignore

--- a/doc/dein.txt
+++ b/doc/dein.txt
@@ -243,9 +243,13 @@ dein#save_cache()
 dein#clear_cache()
 		Clear the cache file manually.
 
-dein#tap({plugin-name})				 *dein#tap()*
+dein#tap({plugin-name})				*dein#tap()*
 		It returns non-zero if {plugin-name} is exists and not
 		disabled.
+
+dein#is_sourced({plugin-name})			*dein#is_sourced()*
+		It returns non-zero if {plugin-name} is exists and sourced.
+		See |dein#source()| and |dein#tap()| as well.
 
 dein#get_log() 					*dein#get_log()*
 		Prints all previous install logs.

--- a/test/base.vim
+++ b/test/base.vim
@@ -1,7 +1,5 @@
 let s:suite = themis#suite('base')
 let s:assert = themis#helper('assert')
-let s:is_windows = has('win16') || has('win32') || has('win64')
-let s:path_separator = s:is_windows ? '\' : '/'
 
 let s:path = tempname()
 

--- a/test/base.vim
+++ b/test/base.vim
@@ -1,5 +1,7 @@
 let s:suite = themis#suite('base')
 let s:assert = themis#helper('assert')
+let s:is_windows = has('win16') || has('win32') || has('win64')
+let s:path_separator = s:is_windows ? '\' : '/'
 
 let s:path = tempname()
 
@@ -64,6 +66,15 @@ function! s:suite.get() abort "{{{
   call s:assert.equals(dein#get('bar').name, 'bar')
   call s:assert.equals(dein#add('foo'), 0)
   call s:assert.equals(dein#get('foo').name, 'foo')
+  call dein#end()
+endfunction"}}}
+
+function! s:suite.tap() abort "{{{
+  call dein#begin(s:path)
+  call s:assert.equals(dein#add('Shougo/neocomplete.vim'), 0)
+  call s:assert.equals(dein#tap('neocomplete.vim'), 0)
+  call s:assert.equals(dein#install(), 0)
+  call s:assert.equals(dein#tap('neocomplete.vim'), 1)
   call dein#end()
 endfunction"}}}
 

--- a/test/base.vim
+++ b/test/base.vim
@@ -78,6 +78,17 @@ function! s:suite.tap() abort "{{{
   call dein#end()
 endfunction"}}}
 
+function! s:suite.is_sourced() abort "{{{
+  call dein#begin(s:path)
+  call s:assert.equals(dein#add('Shougo/neocomplete.vim'), 0)
+  call s:assert.equals(dein#is_sourced('neocomplete.vim'), 0)
+  call s:assert.equals(dein#install(), 0)
+  call s:assert.equals(dein#is_sourced('neocomplete.vim'), 0)
+  call s:assert.equals(dein#source('neocomplete.vim'), 0)
+  call s:assert.equals(dein#is_sourced('neocomplete.vim'), 1)
+  call dein#end()
+endfunction"}}}
+
 function! s:suite.expand() abort "{{{
   call s:assert.equals(dein#_expand('~'),
         \ dein#_substitute_path(fnamemodify('~', ':p')))


### PR DESCRIPTION
First of all, thanks for all of your plugins. These are life changing ;-)

Anyway, I often needs `neobundle#is_sourced()` to check if the plugin has been sourced to determine whether the script should call functions of a plugin or not, to improve the performance.
For example, I don't want to show a python version information which is provided by `vim-pyenv` until I sourced `vim-pyenv` for othre requirements. While the plugin requires several initialization steps, it causes lagging if I source the plugin just for `statusline` in Vim starting. That's why I needed `neobundle#is_sourced()` to check if the plugin has been sourced and determine if a python version information should be obtained or not.

This is a reason why the `neobundle#is_sourced()` was a critical function for me. And I found that the function is missing in `dein.vim`. It seems I can check `sourced` attribute of a plugin instance but I prefer to write `if dein#is_sourced('vim-pyenv')` rather than `if dein#tap('vim-pyenv') && dein#get('vim-pyenv').sourced` because the second one is way too redundant...

So please review the changes :-)

P.S.
Additionally it seems a test No. 14 failed without modifications somehow:

```
not ok 14 - install lazy_on_cmd
# function 99() abort dict  Line:17  (~/Code/github.com/lambdalisue/dein.vim/test/install.vim)
# Vim(call):E117: Unknown function: neocomplete#init#disable
```
