### PR TITLE
Source `ftplugin` after `plugin`

### DIFF
--- a/autoload/dein/autoload.vim
+++ b/autoload/dein/autoload.vim
@@ -223,12 +223,6 @@ function! s:source_plugin(rtps, index, plugin) abort "{{{
 
   let filetype_after = dein#_redir('autocmd FileType')
 
-  if reset_ftplugin
-    call dein#_reset_ftplugin()
-  elseif filetype_before !=# filetype_after
-    execute 'doautocmd FileType' &filetype
-  endif
-
   " Reload script files.
   for directory in filter(['plugin', 'after/plugin'],
         \ "isdirectory(a:plugin.rtp.'/'.v:val)")
@@ -238,6 +232,12 @@ function! s:source_plugin(rtps, index, plugin) abort "{{{
       execute 'silent! unsilent source' fnameescape(file)
     endfor
   endfor
+
+  if reset_ftplugin
+    call dein#_reset_ftplugin()
+  elseif filetype_before !=# filetype_after
+    execute 'doautocmd FileType' &filetype
+  endif
 
   if !has('vim_starting')
     call dein#_call_hook('post_source', a:plugin)


### PR DESCRIPTION
# Problems summary

I'm using [tsuquyomi][], that is a plugin for typescript developing. This plugin has both `ftplugin` and `plugin` files.

I set this with the dein.vim's lazy loading feature that would be sourced `on_ft` events.

I launched vim and open a typescript file, then I found the `ftplugin` seemed to be sourced **before** `plugin`. In this plugin, a function called in `ftplugin` expects that some variables would be defined in `plugin`, so it occurred an error below.

I think NeoBundle would source `ftplugin` **after** `plugin`. The dein.vim behavior is correct or not?

[tsuquyomi]: https://github.com/Quramy/tsuquyomi

## Expected

I want to source `ftplugin` **after** `plugin`.

## Environment Information
 * OS: Mac OS X
 * Vim version: MacVim 7.4.1425

## Provide a minimal .vimrc with less than 50 lines (Required!)

```vim
let s:dein_dir = expand('~/.cache/dein')
let s:dein_repo_dir = s:dein_dir . '/repos/github.com/Shougo/dein.vim'
execute 'set runtimepath^=' . fnamemodify(s:dein_repo_dir, ':p')

call dein#begin(s:dein_dir)
call dein#add('Quramy/tsuquyomi', {'lazy': 1, 'on_ft': ['typescript']})
call dein#end()

if dein#check_install()
  call dein#install()
endif

filetype plugin indent on

autocmd BufNewFile,BufRead *.ts,*.tsx setlocal filetype=typescript
```

## The reproduce ways from Vim starting (Required!)

1. initializing

  ```sh
  rm -fr ~/.cache/dein
  git clone https://github.com/Shougo/dein.vim ~/.cache/dein/repos/github.com/Shougo/dein.vim
  ```

2. `vim -N -u /path/to/vimrc -U NONE -i NONE /tmp/hoge.ts`
3. error! (in `:messages`)

  ```
  Messages maintainer: Bram Moolenaar <Bram@vim.org>
  Not installed plugins:  ['tsuquyomi']
  [dein] Runtimepath updated: (2016/02/28 17:02:06)
  Error detected while processing function
  tsuquyomi#config#preconfig[6]..<SNR>38_deleteCommand:
  line    1:
  E184: No such user-defined command: TsuquyomiStartServer
  line    2:
  E184: No such user-defined command: TsuStartServer
  line    3:
  E184: No such user-defined command: TsuquyomiStopServer
  line    4:
  E184: No such user-defined command: TsuStopServer
  line    5:
  E184: No such user-defined command: TsuquyomiStatusServer
  line    6:
  E184: No such user-defined command: TsuStatusServer
  line    7:
  E184: No such user-defined command: TsuquyomiReloadProject
  line    8:
  E184: No such user-defined command: TsuReloadProject
  [Tsuquyomi] Shougo/vimproc.vim is not installed. Please install it.
  Press ENTER or type command to continue
  ```

4. use roughly-patched fork

  ```sh
  rm -fr ~/.cache/dein
  git clone -b feature/source-ftplugin-after-plugin https://github.com/delphinus35/dein.vim ~/.cache/dein/repos/github.com/Shougo/dein.vim
  ```

5. *2.* again
6. no error!
