### PR TITLE
Ignore an error that occurs when there is no help file

### DIFF
--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -772,6 +772,8 @@ function! s:helptags() abort "{{{
     call s:copy_files(values(dein#get()), 'doc')
 
     silent execute 'helptags' fnameescape(dein#_get_tags_path())
+  catch /^Vim(helptags):E151:/
+    " Ignore an error that occurs when there is no help file
   catch
     call s:error('Error generating helptags:')
     call s:error(v:exception)


### PR DESCRIPTION
When there is no help files, dein.vim reports an error like follows:
![](https://i.gyazo.com/c89240d2b7180c41baf1b1742ed338b9.png)
This PR ignores this.