### PR TITLE
Run CI also on OS X with MacVim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ language: viml
 sudo: required
 dist: trusty
 
+os:
+    - linux
+    - osx
+
 before_script:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install macvim --with-override-system-vim; fi
     - vim --version
     - git clone https://github.com/syngan/vim-vimlint /tmp/vim-vimlint
     - git clone https://github.com/ynkdir/vim-vimlparser /tmp/vim-vimlparser


### PR DESCRIPTION
OS X 上でも CI を実行するようにしました．コンセプトによるとテストを重視しているとのことですので，OS X 対応で大きな効果があると思います．

- Build result example: https://travis-ci.org/rhysd/dein.vim/jobs/112888941
- Ref: https://docs.travis-ci.com/user/osx-ci-environment/