### PR TITLE
Explicitly document that a plugin can be "disabled" with 'if' keyword

### DIFF
--- a/doc/dein.txt
+++ b/doc/dein.txt
@@ -415,9 +415,10 @@ OPTIONS 					*dein-options*
 
 						*dein-options-if*
 		if		(Number) or (String)
-		If set to zero, dein doesn't register the plugin.
+		If set to zero, dein doesn't register the plugin, i.e. the
+		plugin will be disabled.
 		If it is String, dein will eval it.
-		If you don't set it, dein will register the plugin.
+		If you don't set it, dein will register (enable) the plugin.
 
 						*dein-options-timeout*
 		timeout		 (Number)


### PR DESCRIPTION
I learned that a plugin can be **disabled** when reading documentations about `dein#recache_runtimepath()` and `dein#tap()`, but I couldn't find how I can achieve it.

Finally, Shougo kindly told me that we could disable a plugin by `if` keyword.
I think it should be documented in a searchable way, so I added some topical words, like "disabled", to the explanation of `*dein-options-if*`.