### PR TITLE
Do not source when the plugin has been sourced

### DIFF
--- a/autoload/dein/autoload.vim
+++ b/autoload/dein/autoload.vim
@@ -167,6 +167,9 @@ function! dein#autoload#_dummy_complete(arglead, cmdline, cursorpos) abort "{{{
 endfunction"}}}
 
 function! s:source_plugin(rtps, index, plugin) abort "{{{
+  if a:plugin.sourced
+    return
+  endif
   let a:plugin.sourced = 1
 
   let filetype_before = dein#util#_redir('autocmd FileType')


### PR DESCRIPTION
's:source_plugin' possibly called twice or more when the plugin is depended from several plugins.
This commit simply skip if the plugin is already sourced, to prevent unnecessary function call and
&runtimepath duplication.