### PR TITLE
Fix 'Key not present in Dictionary: hook_source' issue

### DIFF
--- a/autoload/dein/util.vim
+++ b/autoload/dein/util.vim
@@ -358,14 +358,14 @@ function! dein#util#_call_hook(hook_name, ...) abort "{{{
   let hook = 'hook_' . a:hook_name
   let plugins = filter(dein#util#_get_plugins((a:0 ? a:1 : [])),
         \ "v:val.sourced && (exists(prefix . v:val.name)
-        \  || !empty(v:val[hook]))")
+        \  || !empty(get(v:val, hook)))")
 
   for plugin in dein#util#_tsort(plugins)
     let autocmd = 'dein#' . a:hook_name . '#' . plugin.name
     if exists('#User#'.autocmd)
       execute 'doautocmd User' autocmd
     endif
-    if !empty(plugin[hook])
+    if !empty(get(plugin, hook))
       for line in plugin[hook]
         try
           execute line


### PR DESCRIPTION
A commit https://github.com/Shougo/dein.vim/commit/50b6e38ed7418ac42861d7103767622c5ebf6220 introduced a bug shown below. That happen every time when I tried to source lazy plugins.
This commit fix that issue.

![selection_013](https://cloud.githubusercontent.com/assets/546312/13897411/6ff4181e-edf4-11e5-89e0-7681eb478f08.png)
