### PR TITLE
Use OS X latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ dist: trusty
 os:
     - linux
     - osx
+osx_image: xcode7.3
 
 before_script:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install macvim --with-override-system-vim; fi


### PR DESCRIPTION
If `osx_image` is empty, Darwin Kernel Version 13.4.0 (Mavericks).
Set `xcode7.3`, Darwin Kernel Version 15.0.0 (El Capitan).