### PR TITLE
Fix install vim to original vim on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
 osx_image: xcode7.3
 
 before_script:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install macvim --with-override-system-vim; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install vim --HEAD; fi
     - vim --version
     - git clone https://github.com/syngan/vim-vimlint /tmp/vim-vimlint
     - git clone https://github.com/ynkdir/vim-vimlparser /tmp/vim-vimlparser


### PR DESCRIPTION
Macvim will occur `Abort trap: 6` error when vim-themis test.
Use original vim HEAD version instead of.