### PR TITLE
Fix dein#update()

### DIFF
--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -826,7 +826,8 @@ function! s:init_process(plugin, context, cmd) abort "{{{
           \ }
 
     if isdirectory(a:plugin.path)
-          \ && get(a:plugin, 'rev', '') != '' && !a:plugin.local
+          \ && get(a:plugin, 'rev', '') != ''
+          \ && !get(a:plugin, 'local', 0)
       let rev_save = get(a:plugin, 'rev', '')
       try
         " Force checkout HEAD revision.


### PR DESCRIPTION
# Problems summary

Since 6287bd38, `call dein#update()` have been failing with plugins specified by `rev` parameters.

## Environment Information
 * OS: Mac OS X 10.11.4
 * Vim version: 7.4.1707

## Provide a minimal .vimrc with less than 50 lines (Required!)

```vim
scriptencoding utf-8

let s:dein_dir = expand('/tmp/test')
let s:dein_repo_dir = s:dein_dir . '/repos/github.com/Shougo/dein.vim'

if &runtimepath !~# '/dein.vim'
  if !isdirectory(s:dein_repo_dir)
    execute '!git clone https://github.com/Shougo/dein.vim' s:dein_repo_dir
  endif
  execute 'set runtimepath^=' . fnamemodify(s:dein_repo_dir, ':p')
endif

if dein#load_state(s:dein_dir)
  call dein#begin(s:dein_dir, [expand('<sfile>')])
  call dein#add('Shougo/unite.vim', {'rev': 'bb2654fdcf79383216b1707c021351a05b630985'})
  call dein#end()
  call dein#save_state()
endif

if dein#check_install()
  call dein#install()
endif

filetype plugin indent on
syntax on
```

## The reproduce ways from Vim starting (Required!)

1. `vim -N -u minimal.vim -U NONE -i NONE`
2. `call dein#update()`
3. error!!

## Upload the log messages by `:redir` and `:message`

```vim
[dein] (1/1): |unite.vim| git pull --ff --ff-only && git submodule update --init --recursive
Error detected while processing function dein#update[1]..dein#install#_update[27]..<SNR>7_install_async[1]..<SNR>7_check_loop[5]..<SNR>7_sync[40]..<SNR>7_init_process:
line   26:
E716: Key not present in Dictionary: local
E15: Invalid expression: isdirectory(a:plugin.path) && get(a:plugin, 'rev', '') != '' && !a:plugin.local
Error detected while processing function dein#update[1]..dein#install#_update[27]..<SNR>7_install_async[1]..<SNR>7_check_loop:
line    5:
E170: Missing :endwhile
Error detected while processing function dein#update[1]..dein#install#_update:
line   27:
E171: Missing :endif
Press ENTER or type command to continue
```