### PR TITLE
Add g:dein#notification_time variable

### DIFF
--- a/autoload/dein/util.vim
+++ b/autoload/dein/util.vim
@@ -67,6 +67,8 @@ function! dein#util#_notify(msg) abort "{{{
         \ 'g:dein#enable_notification', 0)
   call dein#util#_set_default(
         \ 'g:dein#notification_icon', '')
+  call dein#util#_set_default(
+        \ 'g:dein#notification_time', 2)
 
   if !g:dein#enable_notification || a:msg == ''
     return
@@ -77,13 +79,13 @@ function! dein#util#_notify(msg) abort "{{{
   let title = '[dein]'
   let cmd = ''
   if executable('notify-send')
-    let cmd = 'notify-send'
+    let cmd = printf('notify-send --expire-time=%d', g:dein#notification_time * 1000)
     if icon != ''
       let cmd .= ' --icon=' . string(icon)
     endif
     let cmd .= ' ' . string(title) . ' ' . string(a:msg)
   elseif dein#util#_is_windows() && executable('Snarl_CMD')
-    let cmd = printf('Snarl_CMD snShowMessage 2 "%s" "%s"', title, a:msg)
+    let cmd = printf('Snarl_CMD snShowMessage %d "%s" "%s"', g:dein#notification_time, title, a:msg)
     if icon != ''
       let cmd .= ' "' . icon . '"'
     endif

--- a/doc/dein.txt
+++ b/doc/dein.txt
@@ -371,6 +371,13 @@ g:dein#notification_icon
 
 		Defaults: ""
 
+					*g:dein#notification_time*
+g:dein#notification_time
+		This is the time the notification should be displayed in seconds.
+		For Linux and Windows only.
+
+		Defaults: 2
+
  					*g:dein#download_command*
 g:dein#download_command
 		The default download command.


### PR DESCRIPTION
Add a new g:dein#notification_time variable to allow users to set the time notifications should be displayed. Please note that I tested on Linux but not on Windows.