### PR TITLE
Fix wildmenu problem

### DIFF
--- a/autoload/dein/autoload.vim
+++ b/autoload/dein/autoload.vim
@@ -229,11 +229,10 @@ function! dein#autoload#_dummy_complete(arglead, cmdline, cursorpos) abort "{{{
 
   if exists(':'.command)
     " Print the candidates
-    call feedkeys((&wildmode ==# 'full' && &wildmenu ?
-          \ a:arglead : '')."\<C-d>", 'n')
+    call feedkeys("\<C-d>", 'n')
   endif
 
-  return ['']
+  return [a:arglead]
 endfunction"}}}
 
 function! s:source_plugin(rtps, index, plugin, sourced) abort "{{{


### PR DESCRIPTION
@57c740d0af69b38f23c1441777ec8dd15e06a66f では`:Edit .v<C-D> :set wmnu wim=full`な時に候補が更に入力されます
(更に`list:full`や`longest:full`が考慮されてないです)

@57c740d0af69b38f23c1441777ec8dd15e06a66f の以前と以降の調査、修正パッチと作ってみましたが
どれも挙動に微妙な欠点があるので好みの問題かもしれないです

#### before @57c740d0af69b38f23c1441777ec8dd15e06a66f
```vim
" :Edit .v<C-D> :set nowmnu
:Edit .v
:Edit .v
.vim/ .vimrc
:Edit .v

" :Edit .v<C-D> :set wmnu wim=full
:Edit .v
:Edit .v
.vim/ .vimrc
:Edit .v

" :Edit .v<Tab> :set wmnu wim=full
" arglead disappear
:Edit
AppData/
(省略)
:Edit
```

#### @57c740d0af69b38f23c1441777ec8dd15e06a66f
```vim
" :Edit .v<C-D> :set nowmnu
:Edit .v
:Edit .v
.vim/ .vimrc
:Edit .v

" :Edit .v<C-D> :set wmnu wim=full
" arg twice
:Edit .v
:Edit .v.v
:Edit .v.v

" :Edit .v<Tab> :set wmnu wim=full
:Edit .v
.vim/ .vimrc
:Edit .v
```

#### patched
```vim
" :Edit .v<C-D> :set nowmnu
" wasteful output
:Edit .v
.v
:Edit .v
.vim/ .vimrc
:Edit .v

" :Edit .v<C-D> :set wmnu wim=full
" wasteful output
:Edit .v
.v
:Edit .v
.vim/ .vimrc
:Edit .v

" :Edit .v<Tab> :set wmnu wim=full
:Edit .v
.vim/ .vimrc
:Edit .v
```