### PR TITLE
Don't abort when clear runtimepath.

### DIFF
--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -225,7 +225,8 @@ function! s:clear_runtimepath() abort "{{{
   if !isdirectory(parent)
     call mkdir(parent, 'p')
   endif
-  if rename(dein#util#_get_runtime_path(), dest)
+  silent! let err = rename(dein#util#_get_runtime_path(), dest)
+  if get(l:, 'err', -1)
     call dein#util#_error('Rename failed.')
     call dein#util#_error('src=' . dein#util#_get_runtime_path())
     call dein#util#_error('dest=' . dest)


### PR DESCRIPTION
If directory is locked (e.g. Windows), `rename()` is aborted. (E208, E209 or E210)
To handling the error.