### PR TITLE
Fix expand repo in MS Windows

### DIFF
--- a/autoload/dein/parse.vim
+++ b/autoload/dein/parse.vim
@@ -31,7 +31,7 @@ function! dein#parse#_add(repo, options) abort "{{{
   return plugin
 endfunction"}}}
 function! dein#parse#_init(repo, options) abort "{{{
-  let repo = expand(a:repo)
+  let repo = a:repo =~# '^\~' ? expand(a:repo) : a:repo
   let plugin = has_key(a:options, 'type') ?
         \ dein#util#_get_type(a:options.type).init(repo, a:options) :
         \ s:git.init(repo, a:options)


### PR DESCRIPTION
In MS Windows, expand('Shougo/dein.vim') will be 'Shougo\dein.vim'.
I expected this `expand()` to expand head of `~`.  Therefore I added check for it to avoid wrong case.