### PR TITLE
Show branch/revision when available in denite

### DIFF
--- a/rplugin/python3/denite/source/dein.py
+++ b/rplugin/python3/denite/source/dein.py
@@ -6,6 +6,12 @@
 
 from .base import Base
 import re
+import os
+
+
+URL_PATTERN = re.compile('^(https?|git)://(github.com/)?')
+REF_PATTERN = re.compile('^ref: (refs/heads/(.*))$')
+
 
 class Source(Base):
 
@@ -16,7 +22,34 @@ class Source(Base):
         self.kind = 'directory'
 
     def gather_candidates(self, context):
-        pat = re.compile('^(https?|git)://(github.com/)?')
-        return [{'word': pat.sub('', x['repo']),
-                 'action__path': x['path']} for x
-                in self.vim.eval('values(dein#get())')]
+        return [
+            _build_candidate(plugin_context)
+            for plugin_context in self.vim.eval('values(dein#get())')
+        ]
+
+
+def _build_candidate(plugin_context):
+    name = URL_PATTERN.sub('', plugin_context['repo'])
+    path = plugin_context['path']
+    # Find git revision
+    try:
+        revision, branch = _resolve_ref(os.path.join(path, '.git'), 'HEAD')
+    except Exception:
+        # Fail silently
+        revision = ''
+        branch = None
+    rev = revision if branch is None else '%s (%s)' % (branch, revision[:7])
+    return {
+        'word': name,
+        'abbr': name if not rev else '%s -- %s' % (name, rev),
+        'action_path': path,
+    }
+
+
+def _resolve_ref(git, ref, branch=None):
+    with open(os.path.join(git, ref)) as fi:
+        content = fi.readline()
+    m = REF_PATTERN.match(content)
+    if not m:
+        return (content, branch)
+    return _resolve_ref(git, m.group(1), m.group(2))

--- a/rplugin/python3/denite/source/dein.py
+++ b/rplugin/python3/denite/source/dein.py
@@ -42,7 +42,7 @@ def _build_candidate(plugin_context):
     return {
         'word': name,
         'abbr': name if not rev else '%s -- %s' % (name, rev),
-        'action_path': path,
+        'action__path': path,
     }
 
 


### PR DESCRIPTION
I would like to check branch/revision of plugins installed by dein.
Several days ago you said you don't want to show because of the performance issue but this PR does not execute `git` process so I think **this implementation is fast enough**.

![selection_057](https://cloud.githubusercontent.com/assets/546312/21166660/431a9988-c1ea-11e6-9f6d-48a7a25ffd66.png)
