### PR TITLE
Fix the plugin.repo problem

### DIFF
--- a/autoload/dein/parse.vim
+++ b/autoload/dein/parse.vim
@@ -42,7 +42,7 @@ function! dein#parse#_init(repo, options) abort
   if !empty(a:options)
     let plugin.orig_opts = deepcopy(a:options)
   endif
-  return extend(plugin, a:options)
+  return extend(plugin, a:options, 'keep')
 endfunction
 function! dein#parse#_dict(plugin) abort
   let plugin = {

--- a/test/parse.vim
+++ b/test/parse.vim
@@ -23,6 +23,12 @@ function! s:suite.parse_dict() abort
   let parsed_plugin = dein#parse#_dict(dein#parse#_init('', plugin))
   call s:assert.equals(parsed_plugin.merged, 0)
 
+  let $BAZDIR = '/baz'
+  let repo = '$BAZDIR/foo'
+  let plugin = {'repo': repo}
+  let parsed_plugin = dein#parse#_dict(dein#parse#_init(repo, plugin))
+  call s:assert.equals(parsed_plugin.repo, '/baz/foo')
+
   call dein#end()
 endfunction
 


### PR DESCRIPTION
- hoge.toml
```toml
[[plugins]]
repo = '$BAZDIR/foo'
```

など`repo`に環境変数を含む文字列を指定したときに、`plugin.repo` に環境変数が展開された後の文字列が入ることが期待されると思いますが、`dein#parse#_init()`の最後の`extend(plugin, a:options)`で展開前の文字列で上書きされてしまうためその修正になります。