### PR TITLE
Strip newlines in word/abbr

### DIFF
--- a/rplugin/python3/denite/source/dein.py
+++ b/rplugin/python3/denite/source/dein.py
@@ -40,8 +40,8 @@ def _build_candidate(plugin_context):
         branch = None
     rev = revision if branch is None else '%s (%s)' % (branch, revision[:7])
     return {
-        'word': name,
-        'abbr': name if not rev else '%s -- %s' % (name, rev),
+        'word': name.strip(),
+        'abbr': name.strip() if not rev else '%s -- %s' % (name.strip(), rev.strip()),
         'action__path': path,
     }
 


### PR DESCRIPTION
If there is a plugin which checkout a particular commit, the following is shown by `:Denite dein`

```
Error detected while processing function dein#autoload#_on_cmd[13]..denite#helper#call_denite[14]..denite#start[23].._denite_start:
line    1:
[denite] Traceback (most recent call last):
[denite]   File "/Users/alisue/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/__init__.py", line 33, in start
[denite]     return self.__uis[buffer_name].start(args[0], args[1])
[denite]   File "/Users/alisue/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 103, in start
[denite]     self.change_mode(self.__current_mode)
[denite]   File "/Users/alisue/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 388, in change_mode
[denite]     self.update_buffer()
[denite]   File "/Users/alisue/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 263, in update_buffer
[denite]     self.__cursor + self.__winheight))
[denite]   File "/Users/alisue/.anyenv/envs/pyenv/versions/3.5.2/lib/python3.5/site-packages/neovim/api/buffer.py", line 90, in append
[denite]     return self.request('nvim_buf_set_lines', index, index, True, lines)
[denite]   File "/Users/alisue/.anyenv/envs/pyenv/versions/3.5.2/lib/python3.5/site-packages/neovim/api/common.py", line 44, in request
[denite]     return self._session.request(name, self, *args, **kwargs)
[denite]   File "/Users/alisue/.anyenv/envs/pyenv/versions/3.5.2/lib/python3.5/site-packages/neovim/api/nvim.py", line 131, in request
[denite]     res = self._session.request(name, *args, **kwargs)
[denite]   File "/Users/alisue/.anyenv/envs/pyenv/versions/3.5.2/lib/python3.5/site-packages/neovim/msgpack_rpc/session.py", line 98, in request
[denite]     raise self.error_wrapper(err)
[denite] neovim.api.nvim.NvimError: b'string cannot contain newlines'
[denite] Please execute :messages command.
```

This PR fix that particular one. I guess that denite.nvim should remove newlines from word/abbr as well.