### PR TITLE
Fix for bitbucket.org hosted repos

### DIFF
--- a/autoload/dein/types/git.vim
+++ b/autoload/dein/types/git.vim
@@ -93,7 +93,8 @@ function! s:type.get_uri(repo, options) abort
     return ''
   else
     let uri = (protocol ==# 'ssh' &&
-          \    (host ==# 'github.com' || host ==# 'bitbucket.com' || host ==# 'bitbucket.org')) ?
+          \    (host ==# 'github.com' || host ==# 'bitbucket.com' ||
+          \     host ==# 'bitbucket.org')) ?
           \ 'git@' . host . ':' . name :
           \ protocol . '://' . host . '/' . name
   endif

--- a/autoload/dein/types/git.vim
+++ b/autoload/dein/types/git.vim
@@ -93,7 +93,7 @@ function! s:type.get_uri(repo, options) abort
     return ''
   else
     let uri = (protocol ==# 'ssh' &&
-          \    (host ==# 'github.com' || host ==# 'bitbucket.com')) ?
+          \    (host ==# 'github.com' || host ==# 'bitbucket.com' || host ==# 'bitbucket.org')) ?
           \ 'git@' . host . ':' . name :
           \ protocol . '://' . host . '/' . name
   endif


### PR DESCRIPTION
Linked to https://github.com/Shougo/dein.vim/issues/195

Bitbucket uses the bitbucket.org domain by default and in the current state calling dein#update() will complain about not being able to connect to the repository.