### PR TITLE
add a test for check_install()

### DIFF
--- a/test/install.vim
+++ b/test/install.vim
@@ -128,6 +128,7 @@ function! s:suite.check_install() abort
   call s:assert.false(dein#check_install())
   call s:assert.false(dein#check_install(['vimshell.vim']))
   call s:assert.false(dein#check_install(['neocomplete.vim']))
+  call s:assert.true(dein#check_install(['__unknown']))
 
   call dein#end()
 endfunction


### PR DESCRIPTION
先ほど Twitter でメンションした（<https://twitter.com/wtsnjp/status/865836925415849984>）件について，テストを追加してみました．

現状 `check_install()` 関数がインストールされていないプラグイン名を指定した場合も `0` を返してしまうようです．このテストが通るように修正していただければ幸いです．