### PR TITLE
dein#util#_check_clean modified to detect plugins with same name but different repo

### DIFF
--- a/autoload/dein/util.vim
+++ b/autoload/dein/util.vim
@@ -176,8 +176,7 @@ function! dein#util#_check_clean() abort
   let plugins_directories = map(values(dein#get()), 'v:val.path')
   return filter(split(globpath(dein#util#_get_base_path(),
         \ 'repos/*/*/*'), "\n"), "isdirectory(v:val)
-        \   && index(plugins_directories, v:val) < 0
-        \   && empty(dein#get(fnamemodify(v:val, ':t')))")
+        \   && index(plugins_directories, v:val) < 0")
 endfunction
 
 function! dein#util#_writefile(path, list) abort


### PR DESCRIPTION
currently the dein#util#_check_clean doesn't not detect disabled plugins
if there is an enabled plugin with the same name.
for example changing from `tpope/vim-repeat` to `kana/vim-repeat`
this was happening as the last bit of the expression used in the filter
checks if the named plugins in enabled bye doing `dein#get(plugin_name)`

I think this is an uncessary check in the filter since the `plugins_directories`
variable uses the `dein#get()` anyway. Unless the second check is required for
something that I've missed, I suggest removing it so plugins with same name but 
different repo can be detected.
