### PR TITLE
Fix `&runtimepath` list insertion index

### DIFF
--- a/autoload/dein/util.vim
+++ b/autoload/dein/util.vim
@@ -396,7 +396,7 @@ function! dein#util#_begin(path, vimrcs) abort
           \ .' under "&runtimepath/plugin"')
     return 1
   endif
-  call insert(rtps, g:dein#_runtime_path, idx - 1)
+  call insert(rtps, g:dein#_runtime_path, idx)
   call dein#util#_add_after(rtps, g:dein#_runtime_path.'/after')
   let &runtimepath = dein#util#_join_rtp(rtps,
         \ &runtimepath, g:dein#_runtime_path)


### PR DESCRIPTION
This corrects the intended behavior of inserting dein's runtime path immediately prior to `$VIMRUNTIME`, and addresses the edge case where `$VIMRUNTIME` is the first path in `&runtimepath`.

### Brief
Whenever I opened an Objective-C++ file in MacVim, as opposed to any CUI variant, my custom filetype.vim was ignored and `&filetype` was `nroff`.  MacVim's default settings were being prioritized over all of my overrides, most notably my custom filetype.vim.

### Details
I encountered the bug because I cull non-existant directories from `&runtimepath` early in `$MYVIMRC` - see the snippet below - and, when using MacPort's build of MacVim 8.0, this leaves `$VIMRUNTIME` at the beginning of `&runtimepath`.  In this case, the offending line uses an insertion index of `0 - 1` which places dein's runtime path (the anchor for all subsequent insertions) at the end of `rtps`.  After `call dein#end()`, `&runtimepath` looks similar to the following: `[$VIMRUNTIME, {plugin paths}, g:dein#_runtime_path, {plugin after-paths}, ...]`.

```vim
if has('vim_starting')
  ...

  let s:dirs = split(&runtimepath, ',')
  call filter(s:dirs, 'isdirectory(v:val)')
  let &runtimepath = join(s:dirs, ',').','
  \.$XDG_DATA_HOME.'/vim/repos/github.com/Shougo/dein.vim'

  if has('packages')
    let s:dirs = split(&packpath, ',')
    call filter(s:dirs, 'isdirectory(v:val)')
    let &packpath = join(s:dirs, ',')
  endif
  ...

endif
...

if dein#load_state({path to plugin base path directory})
  call dein#begin({path to plugin base path directory})

  call dein#add({path to dein.vim directory})
  call dein#add('Shougo/neocomplete.vim')
  ...

  call dein#end()
  call dein#save_state()
endif
```

### Note
This **could** affect users if they somehow depend on the dein runtime path preceding both `$VIMRUNTIME` and the paths that NeoVim/Vim/MacVim/gVim inserts before `$VIMRUNTIME`.

On my machine, with non-existant-directory culling:
- In NeoVim, `$XDG_DATA_HOME/nvim/site` now appears first in `&runtimepath`.
- In Vim, `$VIM/vimfiles` now appears first in `&runtimepath`.
- In MacVim, dein-controlled plugin paths now properly precede`$VIMRUNTIME` in `&runtimepath`.