### PR TITLE
Check if `exists(':cmdname')` == 2

### DIFF
--- a/autoload/dein/autoload.vim
+++ b/autoload/dein/autoload.vim
@@ -157,7 +157,7 @@ endfunction
 function! dein#autoload#_on_cmd(command, name, args, bang, line1, line2) abort
   call dein#source(a:name)
 
-  if !exists(':' . a:command)
+  if exists(':' . a:command) != 2
     call dein#util#_error(printf('command %s is not found.', a:command))
     return
   endif
@@ -215,7 +215,7 @@ endfunction
 
 function! dein#autoload#_dummy_complete(arglead, cmdline, cursorpos) abort
   let command = matchstr(a:cmdline, '\h\w*')
-  if exists(':'.command)
+  if exists(':'.command) == 2
     " Remove the dummy command.
     silent! execute 'delcommand' command
   endif
@@ -223,7 +223,7 @@ function! dein#autoload#_dummy_complete(arglead, cmdline, cursorpos) abort
   " Load plugins
   call dein#autoload#_on_pre_cmd(tolower(command))
 
-  if exists(':'.command)
+  if exists(':'.command) == 2
     " Print the candidates
     call feedkeys("\<C-d>", 'n')
   endif

--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -412,7 +412,7 @@ function! dein#install#_remote_plugins() abort
   let &runtimepath = dein#util#_join_rtp(dein#util#_uniq(
         \ dein#util#_split_rtp(&runtimepath)), &runtimepath, '')
 
-  if exists(':UpdateRemotePlugins')
+  if exists(':UpdateRemotePlugins') == 2
     UpdateRemotePlugins
   endif
 endfunction


### PR DESCRIPTION
From `:help exists()`:

```
:cmdname  Ex command: built-in command, user
    command or command modifier |:command|.
    Returns:
    1  for match with start of a command
    2  full match with a command
    3  matches several user commands
    To check for a supported command
    always check the return value to be 2.
```