### PR TITLE
Not work ,use dein#plugins2toml for a plugin that stores a dictionary on on_map

### DIFF
--- a/test/parse.vim
+++ b/test/parse.vim
@@ -158,8 +158,10 @@ function! s:suite.plugins2toml() abort
   let parsed_plugin = dein#parse#_init('Shougo/denite.nvim', {})
   let parsed_plugin2 = dein#parse#_init('Shougo/deoplete.nvim',
         \ {'on_ft': ['vim'], 'hook_add': "hoge\npiyo"})
+  let parsed_plugin3 = dein#parse#_init('Shougo/deoppet.nvim',
+        \ {'on_map': {'n': ['a', 'b']}})
   call s:assert.equals(dein#plugins2toml(
-        \ [parsed_plugin, parsed_plugin2]), [
+        \ [parsed_plugin, parsed_plugin2, parsed_plugin3]), [
         \ "[[plugins]]",
         \ "repo = 'Shougo/denite.nvim'",
         \ "",


### PR DESCRIPTION
# Problems summary

```
let parsed_plugin = dein#parse#_init('Shougo/deoppet.nvim', {'on_map': {'n': ['a', 'b']}})
call dein#plugins2toml( [parsed_plugin])
```

```
Error detected while processing function dein#plugins2toml[1]..dein#parse#_plugins2toml:
line   35:
E691: Can only compare List with List
```

## Predict problem

https://github.com/Shougo/dein.vim/blob/master/autoload/dein/parse.vim#L225-L226

## Environment Information

 * dein.vim version(SHA1): ba7b147d21e810401a25d60482a9c7ff2d9347c6

 * OS: MacOS Sierra 10.12.6

 * Vim/neovim version: 0.3.1


## Provide a minimal .vimrc with less than 50 lines

```vim
" Your minimal .vimrc
call dein#plugins2toml( [dein#parse#_init('Shougo/deoppet.nvim', {'on_map': {'n': ['a', 'b']}})])
```


## The reproduce ways from Vim starting

 1. Specify a dictionary storing arrays as mapping in on_map of the plugin
 2. Run plugins2toml for the plugin


## Upload the log messages by `:redir` and `:message`

```
Error detected while processing function dein#plugins2toml[1]..dein#parse#_plugins2toml:
line   35:
E691: Can only compare List with List
```