### PR TITLE
Fix the runtimepath append in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ if &compatible
  set nocompatible
 endif
 " Add the dein installation directory into runtimepath
-set runtimepath+=~/.cache/dein/repos/github.com/Shougo/dein.vim
+set runtimepath^=~/.cache/dein/repos/github.com/Shougo/dein.vim
 
 if dein#load_state('~/.cache/dein')
  call dein#begin('~/.cache/dein')


### PR DESCRIPTION
I'm not sure of the syntax, but this fixed the `:echo has("python3")` being 0 even when python3 neovim module was installed and path to its virtualenv set.