### PR TITLE
Fix checkout branch error

### DIFF
--- a/autoload/dein/types/git.vim
+++ b/autoload/dein/types/git.vim
@@ -180,7 +180,7 @@ function! s:type.get_revision_lock_command(plugin) abort
           \ ])
   endif
 
-  return [self.command, 'checkout', rev]
+  return [self.command, 'checkout', rev, '--']
 endfunction
 function! s:type.get_rollback_command(plugin, rev) abort
   if !self.executable


### PR DESCRIPTION
Install 'mg979/vim-visual-multi'
`call dein#add('mg979/vim-visual-multi',    {'rev': 'test'})`

```
[dein] /Users/yuki_ycino/.vim/bundle/repos/github.com/mg979/vim-visual-multi
[dein] fatal: 'test' could be both a local file and a tracking branch.
[dein] Please use -- (and optionally --no-guess) to disambiguate
```

I modified the command from `git checkout rev` to `git checkout rev --`