### PR TITLE
Fix a typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ if dein#load_state('~/.cache/dein')
 
   call dein#add('~/.cache/dein/repos/github.com/Shougo/dein.vim')
   call dein#add('Shougo/deoplete.nvim')
-  if !has('nvim')
+  if has('nvim')
     call dein#add('roxma/nvim-yarp')
     call dein#add('roxma/vim-hug-neovim-rpc')
   endif


### PR DESCRIPTION
We should install the plugins below only if NeoVim is available.