### PR TITLE
PowerShell compatibility fixes

### DIFF
--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -750,7 +750,7 @@ function! dein#install#_rm(path) abort
     let cmdline = substitute(cmdline, '/', '\\\\', 'g')
   endif
 
-  let rm_command = dein#util#_is_windows() ? 'rmdir /S /Q' : 'rm -rf'
+  let rm_command = dein#util#_is_windows() ? 'cmd /C rmdir /S /Q' : 'rm -rf'
   let cmdline = rm_command . cmdline
   let result = system(cmdline)
   if v:shell_error
@@ -781,7 +781,7 @@ function! dein#install#_copy_directories(srcs, dest) abort
 
     try
       let lines = ['@echo off']
-      let format ='robocopy %s /E /NJH /NJS /NDL /NC /NS /MT /XO /XD ".git"'
+      let format ='robocopy.exe %s /E /NJH /NJS /NDL /NC /NS /MT /XO /XD ".git"'
       for src in a:srcs
         call add(lines, printf(format,
               \                substitute(printf('"%s" "%s"', src, a:dest),

--- a/autoload/dein/types/git.vim
+++ b/autoload/dein/types/git.vim
@@ -125,8 +125,13 @@ function! s:type.get_sync_command(plugin) abort
     let git = self.command
 
     let cmd = g:dein#types#git#pull_command
-    let and = dein#util#_is_fish() ? '; and ' : ' && '
-    let cmd .= and . git . ' submodule update --init --recursive'
+    let submodule_cmd = git . ' submodule update --init --recursive'
+    if dein#util#_is_powershell()
+      let cmd .= '; if ($?) { ' . submodule_cmd . ' }'
+    else
+      let and = dein#util#_is_fish() ? '; and ' : ' && '
+      let cmd .= and . submodule_cmd
+    endif
 
     return git . ' ' . cmd
   endif

--- a/autoload/dein/util.vim
+++ b/autoload/dein/util.vim
@@ -145,6 +145,9 @@ endfunction
 function! dein#util#_is_fish() abort
   return dein#install#_is_async() && fnamemodify(&shell, ':t:r') ==# 'fish'
 endfunction
+function! dein#util#_is_powershell() abort
+  return dein#install#_is_async() && fnamemodify(&shell, ':t:r') =~? 'powershell\|pwsh'
+endfunction
 function! dein#util#_has_job() abort
   return (has('nvim') && exists('v:t_list'))
         \ || (has('patch-8.0.0027') && has('job'))


### PR DESCRIPTION
If PowerShell is set as your `'shell'` on Windows, `rmdir` will try to be the `New-Item` cmdlet instead of cmd.exe's `rmdir` builtin. We can avoid this by specifying `cmd /C rmdir` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shougo/dein.vim/358)
<!-- Reviewable:end -->
