### PR TITLE
Fix robocopy error handler

### DIFF
--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -792,10 +792,9 @@ function! dein#install#_copy_directories(srcs, dest) abort
       call delete(temp)
     endtry
 
-    " For some baffling reason robocopy almost always returns between 1 and 3
-    " upon success
+    " Robocopy returns between 0 and 7 upon success
     let status = dein#install#_status()
-    let status = (status > 3) ? status : 0
+    let status = (status > 7) ? status : 0
 
     if status
       call dein#util#_error('copy command failed.')


### PR DESCRIPTION
## Problem
On Windows, `dein#recache_runtimepath()` throws an error like this.
```
[dein] copy command failed.
[dein] ^I  ^I^I^IC:\Users\harum\work\test\dein\repos\github.com\rhysd\clever-f.vim\.codecov.yml^M  0%  ^M100%
[dein] ^I  ^I^I^IC:\Users\harum\work\test\dein\repos\github.com\rhysd\clever-f.vim\.gitignore^M100%

...

[dein] ^I  ^I^I^IC:\Users\harum\work\test\dein\repos\github.com\sheerun\vim-polyglot\autoload\vital\_crystal\Data\List.vim^M100%
[dein] ^I  ^I^I^IC:\Users\harum\work\test\dein\repos\github.com\sheerun\vim-polyglot\autoload\vital\_crystal\Data\String.vim^M100%
[dein] cmdline: C:\Users\harum\AppData\Local\Temp\nvimlQMybe\2.bat
[dein] tempfile: ['@echo off', 'robocopy.exe "C:\Users\harum\work\test\dein\repos\github.com\rhysd\clever-f.vim" "C:\Users\harum\work\test\dein\.cache\init.vim\.dein" /E /NJH /NJS /NDL /NC /NS /MT /XO /XD ".git"', 'robocopy.exe "C:\Users\harum\work\test\dein\repos\github.com\sheerun\vim-polyglot" "C:\Users\harum\work\test\dein\.cache\init.vim\.dein" /E /NJH /NJS /NDL /NC /NS /MT /XO /XD ".git"']
```

## Provide a minimal .vimrc with less than 50 lines (Required!)

```vim
let s:dein_dir = expand('~/work/test/dein')
let s:dein_repo_dir = s:dein_dir . '/repos/github.com/Shougo/dein.vim' 

execute 'set runtimepath+=' . s:dein_repo_dir

" dein settings 
if dein#load_state(s:dein_dir)
  call dein#begin(s:dein_dir)

  call dein#add('Shougo/dein.vim')
  call dein#add('sheerun/vim-polyglot')
  call dein#add('rhysd/clever-f.vim')

  "finalize
  call dein#end()
  call dein#save_state()
endif

if dein#check_install()
  call dein#install()
endif
```

## solution
According to [this page(Japanese)](https://social.technet.microsoft.com/Forums/office/ja-JP/2b8fbdd8-c268-4261-9fba-47533f67a5b7/robocopy-12398124561252112540-251471242620516?forum=Wcsupportja) or [this(English)](https://ss64.com/nt/robocopy-exit.html), if mismatched directories or files were ditected, robocopy returns error code more than 3. For example, [rhysd/clever-f.vim](https://github.com/rhysd/clever-f.vim) has `test` directory and [sheerun/vim-polyglot](https://github.com/sheerun/vim-polyglot) has `test` file, so dein.vim throws an error.
However, this is not a problem in this context. So dein.vim should allow robocopy errorlevel from 0 to 7.
