### PR TITLE
Fix lazy loading with `on_map` and the `dein_log` unite source

### DIFF
--- a/autoload/dein/parse.vim
+++ b/autoload/dein/parse.vim
@@ -355,11 +355,11 @@ function! s:generate_dummy_mappings(plugin) abort
   let a:plugin.dummy_mappings = []
   let items = type(a:plugin.on_map) == v:t_dict ?
         \ map(items(a:plugin.on_map),
-        \   { _, val -> [split(val[0], '\\zs'),
+        \   { _, val -> [split(val[0], '\zs'),
         \                dein#util#_convert2list(val[1])]}) :
         \ map(copy(a:plugin.on_map),
         \  { _, val -> type(val) == v:t_list ?
-        \     [split(val[0], '\\zs'), val[1:]] : [['n', 'x'], [val]] })
+        \     [split(val[0], '\zs'), val[1:]] : [['n', 'x'], [val]] })
   for [modes, mappings] in items
     if mappings ==# ['<Plug>']
       " Use plugin name.

--- a/autoload/unite/sources/dein_log.vim
+++ b/autoload/unite/sources/dein_log.vim
@@ -44,9 +44,9 @@ function! s:source.async_gather_candidates(args, context) abort
         \   dein#install#_get_updates_log()
         \ : dein#install#_get_log()
   let candidates = map(copy(log[len(a:context.source__log):]), { _, val -> {
-        \ 'word' : (val =~# '^\\s*\\h\\w*://' ? ' -> diff URI' : val),
-        \ 'kind' : (val =~# '^\\s*\\h\\w*://' ? 'uri' : 'word'),
-        \ 'action__uri' : substitute(val, '^\\s\\+', '', ''),
+        \ 'word' : (val =~# '^\s*\h\w*://' ? ' -> diff URI' : val),
+        \ 'kind' : (val =~# '^\s*\h\w*://' ? 'uri' : 'word'),
+        \ 'action__uri' : substitute(val, '^\s\+', '', ''),
         \ } })
   let a:context.source__log = copy(log)
   return candidates


### PR DESCRIPTION
Hi. Lazy loading feature with `on_map` hasn't been working since 71c4297921d51537c61d229722a34e606f2e2a4b because the function for generating dummy mappings uses wrong regular expressions. And the `dein_log` unite source has same problem since 3e663772456c33500ed82229fe751f9e3ee8d023. This Pull Request fixes them. Best regards.