### PR TITLE
Fix installer to abort when detecting execution error

### DIFF
--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -3,6 +3,8 @@
 # Original version is created by shoma2da
 # https://github.com/shoma2da/neobundle_installer
 
+set -e
+
 if [ $# -ne 1 ]; then
   echo "You must specify the installation directory!"
   exit 1


### PR DESCRIPTION
Execution of `bin/installer.sh` might fail for some reasons. For example, `mkdir` might fail when a user tries to install dein to a directory which the user doesn't have a right permission.
However , the installer process will continue even when the error occurs, and finally it seems succeeded with a message `Complete setup dein!` (of course, it has actually failed).

In the following example, a user doesn't have a permission for `~/.test_cache'.

~~~sh
$ sh bin/installer.sh ~/.test_cache/dein
Install to "/Users/egawata/.test_cache/dein/repos/github.com/Shougo/dein.vim"...

git is /usr/local/bin/git

Begin fetching dein...
mkdir: /Users/egawata/.test_cache/dein: Permission denied
fatal: could not create leading directories of '/Users/egawata/.test_cache/dein/repos/github.com/Shougo/dein.vim': Permission denied
Done.

Please add the following settings for dein to the top of your vimrc (Vim) or init.vim (NeoVim) file:


"dein Scripts-----------------------------

(snip)

"End dein Scripts-------------------------


Done.
Complete setup dein!

~~~

I suggest it might be better to make it easy to notice such errors. I fixed the problem to abort when any error occurs during the install process.

~~~sh
$ sh bin/installer.sh ~/.test_cache/dein
Install to "/Users/egawata/.test_cache/dein/repos/github.com/Shougo/dein.vim"...

git is /usr/local/bin/git

Begin fetching dein...
mkdir: /Users/egawata/.test_cache/dein: Permission denied
~~~