### PR TITLE
Fix can't generate cache when hard link was failed

### DIFF
--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -1102,9 +1102,7 @@ function! dein#install#_copy_directories_vim(srcs, dest) abort
   endfor
 endfunction
 function! dein#install#_copy_file_vim(src, dest) abort
-  if has('nvim')
-    call v:lua.vim.loop.fs_symlink(a:src, a:dest)
-  else
+  if !has('nvim') || !v:lua.vim.loop.fs_symlink(a:src, a:dest)
     let raw = readfile(a:src, 'b')
     call writefile(raw, a:dest, 'b')
   endif

--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -963,7 +963,7 @@ function! dein#install#_copy_directories(srcs, dest) abort
   endif
 
   if has('nvim')
-    " Note: For neovim, vim.loop.fs_link is faster
+    " Note: For neovim, vim.loop.fs_symlink is faster
     return dein#install#_copy_directories_vim(a:srcs, a:dest)
   endif
 
@@ -1103,7 +1103,7 @@ function! dein#install#_copy_directories_vim(srcs, dest) abort
 endfunction
 function! dein#install#_copy_file_vim(src, dest) abort
   if has('nvim')
-    call v:lua.vim.loop.fs_link(a:src, a:dest)
+    call v:lua.vim.loop.fs_symlink(a:src, a:dest)
   else
     let raw = readfile(a:src, 'b')
     call writefile(raw, a:dest, 'b')

--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -963,7 +963,7 @@ function! dein#install#_copy_directories(srcs, dest) abort
   endif
 
   if has('nvim')
-    " Note: For neovim, vim.loop.fs_symlink is faster
+    " Note: For neovim, vim.loop.fs_(sym)link is faster
     return dein#install#_copy_directories_vim(a:srcs, a:dest)
   endif
 
@@ -1102,7 +1102,12 @@ function! dein#install#_copy_directories_vim(srcs, dest) abort
   endfor
 endfunction
 function! dein#install#_copy_file_vim(src, dest) abort
-  if !has('nvim') || !v:lua.vim.loop.fs_symlink(a:src, a:dest)
+  " Note: Windows requires administrator privileges
+  "       when using symlink.
+  if !has('nvim')
+        \ || dein#util#_is_windows() ?
+        \     !v:lua.vim.loop.fs_link(a:src, a:dest) :
+        \     !v:lua.vim.loop.fs_symlink(a:src, a:dest)
     let raw = readfile(a:src, 'b')
     call writefile(raw, a:dest, 'b')
   endif


### PR DESCRIPTION
Some cases hard link was failed and not generated cache since https://github.com/Shougo/dein.vim/commit/85e1fc82f430fe4ad8fcd60fe1961be853f9fc13 (e.g. crossing file system boundary)
~`vim.loop.fs_link` will returns boolean value so change to use it and fallback.~
use `vim.loop.fs_symlink` instead of `vim.loop.fs_link`.