### PR TITLE
Add dein#post_sync() for third-party upgrader

### DIFF
--- a/autoload/dein.vim
+++ b/autoload/dein.vim
@@ -151,3 +151,6 @@ endfunction
 function! dein#deno_cache(...) abort
   call dein#install#_deno_cache(get(a:000, 0, []))
 endfunction
+function! dein#post_sync(plugins) abort
+  call dein#install#_post_sync(a:plugins)
+endfunction

--- a/doc/dein.txt
+++ b/doc/dein.txt
@@ -396,6 +396,12 @@ dein#plugins2toml({plugins})
 		Returns the toml configurations for {plugins}
 		{plugins} is the plugins dictionary from |dein#get()|.
 
+							*dein#post_sync()*
+dein#post_sync({plugins})
+		Execute an process needed after the plugins are updated.
+		It can be used to create third-party dein upgrader.
+		{plugins} is the plugins name list that was updated.
+
 							*dein#reinstall()*
 dein#reinstall({plugins})
 		Reinstall the plugins.


### PR DESCRIPTION
I'm creating an ddu-ui to update dein plugins.
It would be useful to create an function that third-party dein update ui can call after update.
