### PR TITLE
Add "Deno-" to "powered" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Please read [help](doc/dein.txt) for details.
 
-Dein.vim is a dark powered Vim/Neovim plugin manager.
+Dein.vim is a dark Deno-powered Vim/Neovim plugin manager.
 
 <!-- vim-markdown-toc GFM -->
 


### PR DESCRIPTION
I noticed you had the same phrase in other similar projects. When I'd looked at this project years ago, I had thought the phrase "dark powered" meant "powered by darkness", which I remember striking me as unusually mystical for a software project description, hahaha! This is also missing from the the small "about" section, but I can't edit that ;)