### PR TITLE
Allow hook functions to be cached in state

### DIFF
--- a/autoload/dein/min.vim
+++ b/autoload/dein/min.vim
@@ -85,6 +85,13 @@ function! dein#min#load_state(path, ...) abort
   if !filereadable(state) | return 1 | endif
   try
     execute 'source' fnameescape(state)
+    if get(g:, 'enable_hook_function_cache', v:false)
+      call map(g:dein#_plugins, {k,v -> empty(map(filter(['hook_add',
+        \ 'hook_source', 'hook_post_source', 'hook_post_update',
+        \ 'hook_done_source'], { _, h -> has_key(v, h)}),
+        \ { _, h -> execute('let v[h] = function("'.get(v[h], 'name').'",'.
+        \ string(get(v[h], 'args')).')')})) ? v : v})
+    endif
   catch
     if v:exception !=# 'Cache loading error'
       call dein#util#_error('Loading state error: ' . v:exception)

--- a/doc/dein.txt
+++ b/doc/dein.txt
@@ -516,6 +516,15 @@ g:dein#download_command
 		Default: "curl --silent --location --output" or "wget -q -O"
 		or use PowerShell.
 
+					*g:dein#enable_hook_function_cache*
+g:dein#enable_hook_function_cache
+		If you set it to 1, function hooks may be used in
+		|dein#save_state()|.
+		See |dein-hooks| notes.
+		Note: lambdas are not supported.
+
+		Defaults: v:false
+
 					*g:dein#enable_name_conversion*
 g:dein#enable_name_conversion
 		If you set it to 1 and omit plugin name,


### PR DESCRIPTION
This PR allows hook functions to be saved with `dein#save_state()` and loaded with `dein#load_state()`.

Lamdas won't work with this PR, those would be more tricky to process. I think only global functions would work. I think `<SID>` may not be reliable from vim instance to vim instance as the `<SID>` for each script might change? So I think only global functions should work with `dein#save_state()` and `dein#load_state()`.

Notes:

* Uses `get({func}, 'name')` and `get({func}, 'args')` to serialize the function in `dein#util#_save_cache()`. This way the function is encoded as strings and works with `json_encode()`.
* `hook_done_update` wasn't in `dein#util#_save_cache()`, so I added that, and changed it to remove lamda functions.
* I changed the warning in `dein#util#_save_state()` to warn only about lambdas.
* Sorry the code is a little complicated in `dein#min#load_state()`. I used a map instead of a for loop as I read that using a map instead is a trick to get faster vimscript.
  * In the outer map() the `empty()? v : v` bit is just to process `g:dein#_plugins` in place. One v branch is if at least one of the hooks were filtered/processed, the other v branch is otherwise.
  * The inner map() assigns the `let v[h] = function(get(v[h], 'name'), get(v[h], 'args'))`, which executes for each hook element `v[h]` the filter() returns. Empty args `[]` works fine in the case of a function with no arguments, no special logic needed for that.

Since this processing would add some processing time to load_state(), the load processing is enabled with a new dein variable: `g:dein#enable_hook_function_cache`

My `vim --startuptime` seems quite variable/inconsistent and I'm not an expert at benchmarking how much extra time this processing would take, i.e. if this new dein variable is worth adding or not. So let me know what you think.

Let me know if you want anything renamed, indented differently, or other changes and I can do that. I don't know if I used the right terminology anyway.

Related #398.