### PR TITLE
Fix dein#toml#syntax() effect with latest nvim-treesitter

### DIFF
--- a/autoload/dein/toml.vim
+++ b/autoload/dein/toml.vim
@@ -4,7 +4,7 @@
 " public api
 "
 function! dein#toml#syntax() abort
-  if has('nvim') && exists(':TSEnableAll')
+  if has('nvim') && exists(':TSBufDisable')
     TSBufDisable highlight
   endif
 


### PR DESCRIPTION
`dein#toml#syntax()` not have effect if using with latest [`nvim-treesitter`](https://github.com/nvim-treesitter/nvim-treesitter).
Because `dein#toml#syntax()` check `:TSEnableAll`, but it has rename to `:TSEnable` at https://github.com/nvim-treesitter/nvim-treesitter/pull/2764 .

https://github.com/Shougo/dein.vim/blob/488b4dfbb66d63c275c5adccfa3e22e4b7b7f005/autoload/dein/toml.vim#L7



`dein#toml#syntax()` contain `nvim-treesitter` command only `:TSBufDisable`.
So, I think that check `:TSBufDisable` is better way.



