### PR TITLE
New installation script for UNIX

### DIFF
--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -26,11 +26,6 @@ USER=${USER:-$(id -u -n)}
 HOME=${HOME:-$(getent passwd $USER 2>/dev/null | cut -d: -f6)}
 HOME=${HOME:-$(eval echo ~$USER)}
 
-# Helper function to verify if command exists
-is_command() {
-  command -v "$@" >/dev/null 2>&1
-}
-
 # Improve user experience formatting messages with colors.
 # Usage: echo -ne "$(ansi 32)"
 # 0: reset; 1: bold; 22: no bold; 30: grey; 31: red; 32: green; 33: yellow; 35: magenta; 36: cyan;
@@ -81,7 +76,7 @@ typography() {
 }
 
 # Make sure git is installed and is executable
-is_command git || {
+command -v git >/dev/null 2>&1 || {
   typography error "Please install git or update your path to include the git executable! Exit error."
   exit 1
 }

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -99,9 +99,9 @@ set nocompatible
 set runtimepath+=$DEIN
 
 " Call dein initialization (required)
-call dein#begin($BASE)
+call dein#begin('$BASE')
 
-call dein#add($DEIN)
+call dein#add('$DEIN')
 
 if !has('nvim')
   call dein#add('roxma/nvim-yarp')

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -122,7 +122,6 @@ if has('syntax')
   syntax on
 endif
 
-
 " Uncomment if you want to install not-installed plugins on startup.
 "if dein#check_install()
 " call dein#install()
@@ -174,6 +173,7 @@ dein_menu() {
 # this function will manually clone the repository.
 dein_setup() {
   typography action "Dein.vim setup initialized..."
+
   git init -q "$DEIN" && cd "$DEIN" &&
     git config fsck.zeroPaddedFilemode ignore &&
     git config fetch.fsck.zeroPaddedFilemode ignore &&

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -4,8 +4,8 @@ set -e
 
 KEEP_CONFIG=no
 
-AUTHOR="Shougen"
-VERSION="2.2"
+AUTHOR="Shougo"
+VERSION="3.0"
 LICENSE="MIT License"
 BRANCH="master"
 REMOTE="https://github.com/Shougo/dein.vim.git"
@@ -98,11 +98,6 @@ call dein#begin('$BASE')
 
 call dein#add('$DEIN')
 
-if !has('nvim')
-  call dein#add('roxma/nvim-yarp')
-  call dein#add('roxma/vim-hug-neovim-rpc')
-endif
-
 " Your plugins go here:
 "call dein#add('Shougo/neosnippet.vim')
 "call dein#add('Shougo/neosnippet-snippets')
@@ -180,8 +175,8 @@ dein_setup() {
     git config receive.fsck.zeroPaddedFilemode ignore &&
     git config core.eol lf &&
     git config core.autocrlf false &&
-    git config oh-my-zsh.remote origin &&
-    git config oh-my-zsh.branch "$BRANCH" &&
+    git config dein.vim.remote origin &&
+    git config dein.vim.branch "$BRANCH" &&
     git remote add origin "$REMOTE" &&
     git fetch --depth=1 origin -q &&
     git checkout -b "$BRANCH" "origin/$BRANCH" -q || {

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -36,10 +36,13 @@ ansi() {
 # If stdout is not a terminal ignore all formatting
 [ -t 1 ] || ansi() { :; }
 
+# Reset the terminal. Used to clear the screen in each step of
+# the installation process.
 reset_clb() {
   printf '\33c\x1B[3J'
 }
 
+# This function handle the format of the script messages.
 typography() {
   case $1 in
   "title")
@@ -175,8 +178,6 @@ dein_setup() {
     git config receive.fsck.zeroPaddedFilemode ignore &&
     git config core.eol lf &&
     git config core.autocrlf false &&
-    git config dein.vim.remote origin &&
-    git config dein.vim.branch "$BRANCH" &&
     git remote add origin "$REMOTE" &&
     git fetch --depth=1 origin -q &&
     git checkout -b "$BRANCH" "origin/$BRANCH" -q || {

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -2,7 +2,11 @@
 
 set -e
 
-KEEP_CONFIG=no
+# The script argumets changes the following variables:
+#
+# KEEP_CONFIG - If set to yes will save the new generated config to the dein.vim base path.
+#               Otherwise, it will overwrite the config.
+KEEP_CONFIG=yes
 
 AUTHOR="Shougo"
 VERSION="3.0"
@@ -221,7 +225,7 @@ dein() {
   # Handle script arguments
   while [ $# -gt 0 ]; do
     case $1 in
-    --keep-config | -K) KEEP_CONFIG=yes ;;
+    --overwrite-config | -oWC) KEEP_CONFIG=no;;
     esac
     shift
   done

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -166,7 +166,7 @@ dein_menu() {
       break
       ;;
     2)
-      export BASE="${HOME}/.local/share/dein/"
+      export BASE="${HOME}/.local/share/dein"
       break
       ;;
     esac


### PR DESCRIPTION
Hi, Ned here.
In this script, all the logic I used was production-ready and in active use. I guess there shouldn't be any problem with this one.

However, I still ask if you have a working UNIX (eg. macOS or Linux Distros) test this out. Any feedback is appreciated.

## Features

- **Menu** - Tiny & clean prompts to help new users customize their installation.
- **Git clone** - Manually git clone the repo to provide support for older git versions.
- **Config** - Automatically generate the config based on the user choices.
- **Colored logs** - Provide an more easier on the eyes installation proccess with colorful log messages.
- **One liner usage** - Give the possibility to install dein.vim with just one line for UNIX's users.
- **Tiny** - The script size is less than 7.5K.

## Examples
Test the new script by running one of the following commands:

```sh
# curl
sh -c "$(curl -fsSL https://raw.githubusercontent.com/santosned/dein.vim/master/bin/installer.sh)"
# or wget
sh -c "$(wget https://raw.githubusercontent.com/santosned/dein.vim/master/bin/installer.sh -O -)"
```
In some case users might wan't to keep the current vim config, so to handle that I added the ```--keep-config | -K``` arguments, which can be passed to the installation script, like this:

```sh
# curl
sh -c "$(curl -fsSL https://raw.githubusercontent.com/santosned/dein.vim/master/bin/installer.sh)" "" --keep-config
```
When needed this will allow the script to verify if the vim or nvim config exist, if true it'll generate the ```.vimrc``` config at the dein.vim **base path**, if false it'll overwrite any config if existent.

## Issues

Closes #467 