### PR TITLE
Add dein path vars in the initial config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ To learn more details, visit [here](doc/dein.txt).
       - [Additional Notes](#additional-notes)
     - [Powershell (Windows)](#powershell-windows)
     - [Config example](#config-example)
-  - [Q&A](#qa)
-      - [Dein supports NeoBundle?](#dein-supports-neobundle)
+  - [Q\&A](#qa)
       - [Dein has an user interface like vim-plug?](#dein-has-an-user-interface-like-vim-plug)
   - [Feedback](#feedback)
   - [Tasks](#tasks)
@@ -155,13 +154,19 @@ Lastly, for an installation at the `~/.cache/dein` directory execute:
 " well as sanely reset options when re-sourcing .vimrc
 set nocompatible
 
+" Set dein base path (required)
+let s:dein_base = '~/.cache/dein/'
+
+" Set dein source path (required)
+let s:dein_src = '~/.cache/dein/repos/github.com/Shougo/dein.vim'
+
 " Set dein runtime path (required)
-set runtimepath+=/home/{Your username}/.cache/dein/repos/github.com/Shougo/dein.vim
+set runtimepath+=s:dein_src
 
 " Call dein initialization (required)
-call dein#begin('/home/{Your username}/.cache/dein/')
+call dein#begin(s:dein_base)
 
-call dein#add('/home/{Your username}/.cache/dein/repos/github.com/Shougo/dein.vim')
+call dein#add(s:dein_src)
 
 " Your plugins go here:
 "call dein#add('Shougo/neosnippet.vim')

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -100,19 +100,25 @@ generate_vimrc() {
 " well as sanely reset options when re-sourcing .vimrc
 set nocompatible
 
-" Set dein runtime path (required)
-set runtimepath+=$DEIN
+" Set Dein base path (required)
+let s:dein_base = '$BASE'
 
-" Call dein initialization (required)
-call dein#begin('$BASE')
+" Set Dein source path (required)
+let s:dein_src = '$DEIN'
 
-call dein#add('$DEIN')
+" Set Dein runtime path (required)
+set runtimepath+=s:dein_src
+
+" Call Dein initialization (required)
+call dein#begin(s:dein_base)
+
+call dein#add(s:dein_src)
 
 " Your plugins go here:
 "call dein#add('Shougo/neosnippet.vim')
 "call dein#add('Shougo/neosnippet-snippets')
 
-" Finish dein initialization (required)
+" Finish Dein initialization (required)
 call dein#end()
 
 " Attempt to determine the type of a file based on its name and possibly its


### PR DESCRIPTION
This is to mitigate problems related to the 2 required paths that could appear. Also helps users keep their config file more clean.