### PR TITLE
fix: bashism

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ following **wget** or **curl** command:
 #### Wget
 
 ```sh
-sh -c "$(wget -O- https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh)"
+bash -c "$(wget -O- https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh)"
 ```
 
 
 #### Curl
 
 ```sh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh)"
 ```
 
 
@@ -96,8 +96,8 @@ check if the code is safe:
 
 ```sh
 $ wget https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh
-$ less install.sh
-$ sh install.sh
+$ less installer.sh
+$ bash installer.sh
 ```
 
 The script code is well formated, so you can better understand all the code.
@@ -114,7 +114,7 @@ section below.
 
 - The `installer` script has prompt menus that helps you setup everything.
   However, if you want install **Dein.vim** into an different path location,
-  pass the location to the end of the script like `sh install.sh
+  pass the location to the end of the script like `bash installer.sh
   ~/.vim/bundle`.
 
 

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
The shebang of `bin/installer.sh` is `#!/bin/sh` but it is not POSIX-compatible:

- `read -p`: https://github.com/Shougo/dein.vim/blob/71550179444d3cbde5ac12f68b66e4b0ceb01a3e/bin/installer.sh#L144, https://github.com/Shougo/dein.vim/blob/71550179444d3cbde5ac12f68b66e4b0ceb01a3e/bin/installer.sh#L164
- `&>`: https://github.com/Shougo/dein.vim/blob/71550179444d3cbde5ac12f68b66e4b0ceb01a3e/bin/installer.sh#L194, https://github.com/Shougo/dein.vim/blob/71550179444d3cbde5ac12f68b66e4b0ceb01a3e/bin/installer.sh#L200

The simplest solution, I believe, is to use `bash`.