### PR TITLE
🚀 Major improvement of UNIX installer script

### DIFF
--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -222,7 +222,7 @@ base_prompt() {
 dein_setup() {
   typography action "Cloning Dein.vim into '$DEIN'..."
 
-  command git init -q "$DEIN" &&
+  (command git init -q "$DEIN" &&
     command cd "$DEIN" >>/dev/null 2>&1 &&
     command git config fsck.zeroPaddedFilemode ignore &&
     command git config fetch.fsck.zeroPaddedFilemode ignore &&
@@ -231,7 +231,7 @@ dein_setup() {
     command git config core.autocrlf false &&
     command git remote add origin "$REMOTE" &&
     command git fetch --depth=1 origin "$BRANCH" &&
-    command git checkout "$BRANCH" -q ||
+    command git checkout "$BRANCH" -q) ||
     {
       cd -
       cleanup

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -233,7 +233,7 @@ dein() {
   while [ $# -gt 0 ]; do
     case $1 in
     --overwrite-config | -oWC) KEEP_CONFIG=no ;;
-    *./* | */home/* | *~/*) BASE=$(eval echo "$1") ;;
+    *./* | */home/* | *~/*) BASE=$(eval echo "${1%/}") ;;
     --use-vim-config | -uVC) VIMRC="${HOME}/.vimrc" ;;
     --use-neovim-config | -uNC) VIMRC="${HOME}/.config/nvim/init.vim" ;;
     *)

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -271,16 +271,16 @@ dein() {
     ;;
   esac
 
+  case $VIMRC in
+  none) config_prompt ;;
+  esac
+
   DEIN="${BASE}/repos/github.com/Shougo/dein.vim"
 
   if [ -d "$DEIN" ]; then
     typography warning "The DEIN folder already exists ($DEIN).\nYou'll need to move or remove it."
     exit 1
   fi
-
-  case $VIMRC in
-  none) config_prompt ;;
-  esac
 
   typography title
   dein_setup

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -82,9 +82,7 @@ typography() {
   "input") printf "\n%s\n" "$2" ;;
   "action") printf "%s$2%s\n" "$(ansi 36)" "$(ansi 0)" ;;
   "action_warn") printf "%s$2%s %s$3%s\n" "$(ansi 33)" "$(ansi 0)" "$(ansi 36)" "$(ansi 0)" ;;
-  "error")
-    printf "%sError:  $2%s\n" "$(ansi 31)" "$(ansi 0)"
-    ;;
+  "error") printf "%sError:  $2%s\n" "$(ansi 31)" "$(ansi 0)" ;;
   *) printf "" ;;
   esac
 }
@@ -175,18 +173,21 @@ config_backup() {
 
 # Prompt the user for the vim config path location.
 config_prompt() {
-  while typography header "CONFIG LOCATION" &&
-    typography input_opt "1" "vim" "path" "(~/.vimrc)" &&
-    typography input_opt "2" "neovim" "path" "(~/.config/nvim/init.vim)" &&
-    typography input "Select your editor config location (eg. 1 or 2)" && read -r OPT_CL; do
+  while
+    typography header "CONFIG LOCATION" &&
+      typography input_opt "1" "vim" "path" "(~/.vimrc)" &&
+      typography input_opt "2" "neovim" "path" "(~/.config/nvim/init.vim)" &&
+      typography input "Select your editor config location (eg. 1 or 2)" &&
+      read -r OPT_CL
+  do
     case $OPT_CL in
     1)
-      CONFIG_LOCATION="${HOME}"
+      CONFIG_LOCATION="$HOME"
       CONFIG_FILENAME=".vimrc"
       break
       ;;
     2)
-      CONFIG_LOCATION="${HOME}/.config/nvim"
+      CONFIG_LOCATION="$HOME/.config/nvim"
       CONFIG_FILENAME="init.vim"
       break
       ;;
@@ -196,18 +197,20 @@ config_prompt() {
 
 # Prompt the user for the dein.vim base path location.
 base_prompt() {
-  while typography header "DEIN.VIM LOCATION" &&
-    typography input_opt "1" "cache" "path" "(~/.cache/dein)" &&
-    typography input_opt "2" "local" "path" "(~/.local/share/dein)" &&
-    typography input "Select dein.vim location to clone with git (eg. 1 or 2)" &&
-    read -r OPT_DL; do
+  while
+    typography header "DEIN.VIM LOCATION" &&
+      typography input_opt "1" "cache" "path" "(~/.cache/dein)" &&
+      typography input_opt "2" "local" "path" "(~/.local/share/dein)" &&
+      typography input "Select dein.vim location to clone with git (eg. 1 or 2)" &&
+      read -r OPT_DL
+  do
     case $OPT_DL in
     1)
-      BASE="${HOME}/.cache/dein"
+      BASE="$HOME/.cache/dein"
       break
       ;;
     2)
-      BASE="${HOME}/.local/share/dein"
+      BASE="$HOME/.local/share/dein"
       break
       ;;
     esac
@@ -228,12 +231,13 @@ dein_setup() {
     command git config core.autocrlf false &&
     command git remote add origin "$REMOTE" &&
     command git fetch --depth=1 origin "$BRANCH" &&
-    command git checkout "$BRANCH" -q || {
-    cd -
-    cleanup
-    typography error "Git clone of dein.vim repo failed"
-    exit 1
-  }
+    command git checkout "$BRANCH" -q ||
+    {
+      cd -
+      cleanup
+      typography error "Git clone of dein.vim repo failed"
+      exit 1
+    }
 
   command cd - >>/dev/null 2>&1 || {
     typography error "Failed to exit installation directory"
@@ -279,11 +283,11 @@ dein() {
     --overwrite-config | -oWC) KEEP_CONFIG=no ;;
     *./* | */home/* | *~/*) BASE=$(eval echo "${1%/}") ;;
     --use-vim-config | -uVC)
-      CONFIG_LOCATION="${HOME}"
+      CONFIG_LOCATION="$HOME"
       CONFIG_FILENAME=".vimrc"
       ;;
     --use-neovim-config | -uNC)
-      CONFIG_LOCATION="${HOME}/.config/nvim"
+      CONFIG_LOCATION="$HOME/.config/nvim"
       CONFIG_FILENAME="init.vim"
       ;;
     *)

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -191,15 +191,16 @@ base_prompt() {
 dein_setup() {
   typography action "Dein.vim setup initialized..."
 
-  git init -q "$DEIN" && cd "$DEIN" &&
-    git config fsck.zeroPaddedFilemode ignore &&
-    git config fetch.fsck.zeroPaddedFilemode ignore &&
-    git config receive.fsck.zeroPaddedFilemode ignore &&
-    git config core.eol lf &&
-    git config core.autocrlf false &&
-    git remote add origin "$REMOTE" &&
-    git fetch --depth=1 origin -q &&
-    git checkout -b "$BRANCH" "origin/$BRANCH" -q || {
+  command git init -q "$DEIN" &&
+    command cd "$DEIN" >>/dev/null 2>&1 &&
+    command git config fsck.zeroPaddedFilemode ignore &&
+    command git config fetch.fsck.zeroPaddedFilemode ignore &&
+    command git config receive.fsck.zeroPaddedFilemode ignore &&
+    command git config core.eol lf &&
+    command git config core.autocrlf false &&
+    command git remote add origin "$REMOTE" &&
+    command git fetch --depth=1 origin "$BRANCH" &&
+    command git checkout "$BRANCH" -q || {
     cd -
     cleanup
     typography error "Git clone of dein.vim repo failed"

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -139,6 +139,14 @@ endif
 EOF
 }
 
+# Handle the cleanup before exiting error. It should be used with caution.
+cleanup() {
+  # Remove cloned Dein.vim repository, if any.
+  [ ! -d "$DEIN" ] || {
+    rm -rf "$DEIN" >>/dev/null 2>&1
+  }
+}
+
 # Prompt the user for the vim config path location.
 config_prompt() {
   while typography header "CONFIG LOCATION" &&
@@ -192,10 +200,8 @@ dein_setup() {
     git remote add origin "$REMOTE" &&
     git fetch --depth=1 origin -q &&
     git checkout -b "$BRANCH" "origin/$BRANCH" -q || {
-    [ ! -d "$DEIN" ] || {
-      cd -
-      rm -rf "$DEIN" >>/dev/null 2>&1
-    }
+    cd -
+    cleanup
     typography error "Git clone of dein.vim repo failed"
     exit 1
   }
@@ -223,6 +229,7 @@ editor_setup() {
   if command echo "$(generate_vimrc)" >"$OUTDIR"; then
     typography action "Config file created successfully!" "($OUTDIR)"
   else
+    cleanup
     typography error "Failed to generate vim config file. ($OUTDIR)\nMake sure the directory exists and you have access to it."
     exit 1
   fi

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -11,10 +11,10 @@ BASE=none
 # Store the dein.vim path location (eg. '~/.cache/dein/repos/github.com/Shougo/dein.vim')
 DEIN=none
 
-# Store the Vim or Neovim config file (eg. 'init.vim')
+# Store the Vim or Neovim config file (eg. '.vimrc' or 'init.vim')
 CONFIG_FILENAME=none
 
-# Store the path of the Vim or Neovim config file (eg. '~/.config/nvim')
+# Store the path to the Vim or Neovim config file (eg. '~/' or '~/.config/nvim')
 CONFIG_LOCATION=none
 
 AUTHOR="Shougo"

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -76,10 +76,10 @@ typography() {
     ;;
   "output") printf "%s\n$2\n%s\n" "$(ansi 32)" "$(ansi 0)" ;;
   "input_opt") printf "%s$2%s %s$3%s %s$4%s %s$5%s\n" "$(ansi 1 35)" "$(ansi 0)" "$(ansi 36)" "$(ansi 0)" "$(ansi 0 34)" "$(ansi 0)" "$(ansi 1 35)" "$(ansi 0)" ;;
-  "input") printf "\n%s%s$2\n" "$(ansi 32)" "$(ansi 0)";;
+  "input") printf "\n%s%s$2\n" "$(ansi 32)" "$(ansi 0)" ;;
   "action") printf "%s%s $2 %s$3%s\n" "$(ansi 36)" "$(ansi 0)" "$(ansi 36)" "$(ansi 0)" ;;
   "error") printf "%sError: $2%s\n" "$(ansi 31)" "$(ansi 0)" ;;
-  "warning") printf "%sWarning: $2%s\n" "$(ansi 33)" "$(ansi 0)";;
+  "warning") printf "%sWarning: $2%s\n" "$(ansi 33)" "$(ansi 0)" ;;
   *) printf "" ;;
   esac
 }
@@ -233,7 +233,7 @@ dein() {
   while [ $# -gt 0 ]; do
     case $1 in
     --overwrite-config | -oWC) KEEP_CONFIG=no ;;
-    ./* | /home/* | ~/*) BASE=$(echo "$1") ;;
+    *./* | */home/* | *~/*) BASE=$(eval echo "$1") ;;
     --use-vim-config | -uVC) VIMRC="${HOME}/.vimrc" ;;
     --use-neovim-config | -uNC) VIMRC="${HOME}/.config/nvim/init.vim" ;;
     *)

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -223,6 +223,17 @@ editor_setup() {
   if [ -e "$VIMRC" ] && [ $KEEP_CONFIG = "yes" ]; then
     typography warning "Found old editor config. Generating config in the base path.\nRun 'cat $BASE/.vimrc' in your terminal to check it out."
     OUTDIR="$BASE/.vimrc"
+  else
+    case $VIMRC in
+    *.config/nvim/init.vim)
+      # Create the Neovim config folder if it doesn't exist already.
+      command mkdir -p "$(dirname -- "$VIMRC")" >>/dev/null 2>&1 || {
+        cleanup
+        typography error "Failed to create Neovim folder, try creating '$VIMRC' folder manually before continue."
+        exit 1
+      }
+      ;;
+    esac
   fi
 
   OUTDIR=${OUTDIR:-$VIMRC}

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -89,7 +89,7 @@ typography() {
 
 # Make sure git is installed and is executable
 command -v git >>/dev/null 2>&1 || {
-  typography error "Couldn't find 'git' command. Make sure 'git' is installed and is executable before continue."
+  typography error "Couldn't find 'git' command. Make sure 'git' is installed and it's executable before continue."
   exit 1
 }
 


### PR DESCRIPTION
I've refactored and added some functionalities to improve the overall experience while running the UNIX installer script.

## Changes

- add: support for quoted base path arguments
- add: strip final slash of base path arguments automatically
- add: function to clean up before exiting error
- refact: improve manual clone of the repository
- add: create Neovim config folder when needed
- refact: improve call stack order of prompt menus
- refact: split editor config path variables in two
- refact: improve overall log messages
- add: backup for existing config file automatically
- fix: Run Shellcheck and Shell code formatter

## Important notes

### Cleanup on error

The script will now automatically delete the cloned Dein.vim repo when the script runs into a major error. This allows the script to run again without showing the `Error: Folder already exists.` message.

**Obs.:** I wonder if we could delete the existing cloned repo automatically? This way this `Error: Folder already exists.`  message would probably never appear.

### Existing config

Any existing Vim or Neovim config file will be saved inside a backup file with a unique suffix (eg. `.pre-dein-vim` or `-{TIMESTAMP}.pre-dein-vim`) in the same directory. The `{TIMESTAMP}` is the date that the backup was created in the format `month-day-year-hour-minutes-seconds`, the timestamp will only be added when dealing with multiple backup files.

### CLI Arguments

The base path command line argument now supports an quoted path argument (eg. `sh ./installer.sh "~/.cache/dein"`) or an path with trailing slash (eg. `sh ./installer.sh ~/.cache/dein/`). However, the matching rule has become more shallow/generic to allow quoted paths, which could possible cause some rare edge-cases problems. Since the main-cases works just fine, I still added it.

## Other notes

The Git log messages will now be logged, especially from the `git fetch` command, since it's relevant to at least have an downloading feedback.

The ending messages of the installer script will now have more relevant informations such as documentation, chat, and report link.
