### PR TITLE
fix lua api return value

### DIFF
--- a/lua/dein.lua
+++ b/lua/dein.lua
@@ -11,7 +11,7 @@ local M = setmetatable({}, {
       local ret = vim.call('dein#' .. key, ...)
 
       -- NOTE: For boolean functions
-      if vim.startswith(key, 'check_') or vim.startswith(key, 'is_') then
+      if type(ret)~='table' and (vim.startswith(key, 'check_') or vim.startswith(key, 'is_')) then
         ret = ret ~= 0
       end
 


### PR DESCRIPTION
Some functions with prefix `check_`(`check_clean`,`check_lazy_plugins`) returns a `table` and should not converted to `boolean`. This PR prevents converting to `boolean` if function return value is a `table`.

Note:
I am not familiar with the internal code. So just drop some comments if there is another better way to fix it.