### PR TITLE
Don't ignore the "Done" message of `dein#check_update()` even if there are no updated plugins

### DIFF
--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -1753,16 +1753,20 @@ endfunction
 function! s:notify(msg) abort
   let msg = dein#util#_convert2list(a:msg)
   let context = s:global_context
-  if empty(msg) || empty(context)
+  if empty(msg)
+    return
+  endif
+
+  call s:updates_log(msg)
+  let s:progress = join(msg, "\n")
+
+  if empty(context)
     return
   endif
 
   if context.message_type ==# 'echo'
     call dein#util#_notify(a:msg)
   endif
-
-  call s:updates_log(msg)
-  let s:progress = join(msg, "\n")
 endfunction
 function! s:updates_log(msg) abort
   let msg = dein#util#_convert2list(a:msg)


### PR DESCRIPTION
Hi. Thanks for developing dein.vim. No dein.vim, no my Vim life.

I have an issue that the "Done" message, e.g., "Done: (2023/01/02 03:04:05)", of `dein#check_update()` is ignored if there are no updated plugins. This issue is caused as follows:

1. `dein#check_update()` calls [`dein#install#_check_update()`](https://github.com/Shougo/dein.vim/blob/784238b77b8d789ddd8d5014a7991b8d6343ddbd/autoload/dein/install.vim#L263) internally
2. `dein#install#_check_update()` calls [`dein#install#_get_updated_plugins()`](https://github.com/Shougo/dein.vim/blob/784238b77b8d789ddd8d5014a7991b8d6343ddbd/autoload/dein/install.vim#L115) and checks if there are updated plugins
3. If there are no updated plugins, dein.vim calls [`s:notify()`](https://github.com/Shougo/dein.vim/blob/784238b77b8d789ddd8d5014a7991b8d6343ddbd/autoload/dein/install.vim#L1753) for sending the "Done" message and finishes its update process
4. Because the variable `context` is empty, `s:notify()` does nothing and the "Done" message is ignored
    * The `context` is derived from `s:global_context`, that is empty because [`dein#install#_get_updated_plugins()` makes it empty](https://github.com/Shougo/dein.vim/blob/784238b77b8d789ddd8d5014a7991b8d6343ddbd/autoload/dein/install.vim#L258)

This pull request fixes the issue. Even if `context` is empty, `s:notify()` will call `s:updates_log()` and assign `s:progress`. Then only if `context` isn't empty, `s:notify()` will check `context.message_type` and call `dein#util#_notify()`.