### PR TITLE
Remove useless `if has('filetype')` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,7 @@ call dein#end()
 " Attempt to determine the type of a file based on its name and possibly its
 " contents. Use this to allow intelligent auto-indenting for each filetype,
 " and for plugins that are filetype specific.
-if has('filetype')
-  filetype indent plugin on
-endif
+filetype indent plugin on
 
 " Enable syntax highlighting
 if has('syntax')


### PR DESCRIPTION
`filetype` is not a feature, and it can be used as long as vim is compiled with `eval` feature.