### PR TITLE
Fix cannot load `vital.vim` by `on_func = 'vital#vital#'`

### DIFF
--- a/autoload/dein/autoload.vim
+++ b/autoload/dein/autoload.vim
@@ -171,7 +171,7 @@ endfunction
 function! dein#autoload#_on_func(name) abort
   let function_prefix = substitute(a:name, '[^#]*$', '', '')
   if function_prefix =~# '^dein#'
-        \ || function_prefix =~# '^vital#'
+        \ || (function_prefix !~# '^vital#vital#' && function_prefix =~# '^vital#')
     return
   endif
 


### PR DESCRIPTION
## Problems summary

I configured vital.vim as lazy with `on_func: 'vital#vital#'`.

dein.vim doesn't load vital.vim on executing `let s:V = vital#vital#new()`.

## Environment

OS: Arch Linux (WSL)

Vim/Neovim version: `NVIM v0.9.0-dev-708+ge7ea15660`

dein.vim version: ea1a48cf

## Minimal configuration

 init.vim

```vim
const s:here = fnamemodify(expand('<sfile>:p'), ':h')
const s:dein_cache = s:here .. '/dein'
const s:dein_dir = s:dein_cache .. '/repos/github.com/Shougo/dein.vim'

if &rtp !~# '/dein.vim'
  if !isdirectory(s:dein_dir)
    call system(printf('git clone https://github.com/Shougo/dein.vim.git --depth 1 %s', s:dein_dir))
  endif
  execute printf('set rtp^=%s', s:dein_dir)
endif

call dein#begin(s:dein_cache)

call dein#add('vim-jp/vital.vim', #{ lazy: 1, on_func: 'vital#vital#' })

call dein#end()

if dein#check_install()
  call dein#install()
endif

const s:Vital = vital#vital#new()
```
