### PR TITLE
Feat: Add `g:dein#detect_help_filetype` option

### DIFF
--- a/doc/dein.txt
+++ b/doc/dein.txt
@@ -522,6 +522,15 @@ g:dein#default_options
 
 		Default: {}
 
+						*g:dein#detect_help_filetype*
+g:dein#detect_help_filetype
+		|dein| detects markdown headers of README.md as help tags
+		when a plugin contains no files like `doc/*.txt`.
+		If this option is enabled, |'filetype'| will be set to
+		`markdown` on |BufWinEnter| fired.
+
+		Default: v:false
+
 						*g:dein#download_command*
 g:dein#download_command
 		The default download command.

--- a/ftdetect/dein.vim
+++ b/ftdetect/dein.vim
@@ -1,0 +1,11 @@
+function! s:DetectHelpFileType() abort
+  if !get(g:, 'dein#detect_help_filetype', v:false)
+    return
+  endif
+
+  if expand('<afile>')->fnamemodify(':e') ==# 'md'
+    autocmd dein BufWinEnter <buffer> ++once setfiletype markdown
+  endif
+endfunction
+
+autocmd dein FileType help call s:DetectHelpFileType()


### PR DESCRIPTION
dein.vim creates help tags of `README.md` now.

`'filetype'` option will be automatically set to `help` by `:help` command.

Users can overwrite that behavior by

```vim
let g:dein#detect_help_filetype = v:true
```