### PR TITLE
Fixed loading ftplugin at hooks_file written in lua script.

### DIFF
--- a/autoload/dein/parse.vim
+++ b/autoload/dein/parse.vim
@@ -498,7 +498,11 @@ function! dein#parse#_hooks_file(filename) abort
               \ printf('Invalid hook name %s: %s', a:filename, line))
         return {}
       endif
-      if hook_name->stridx('hook_') == 0 || hook_name->stridx('lua_') == 0
+      if hook_name->stridx('hook_') == 0
+            \ || hook_name->stridx('lua_add') == 0
+            \ || hook_name->stridx('lua_source') == 0
+            \ || hook_name->stridx('lua_done_') == 0
+            \ || hook_name->stridx('lua_post_') == 0
         let dest = options
       else
         if !(options->has_key('ftplugin'))


### PR DESCRIPTION
In the original conditional expression `hook_name->stridx('lua_')`,
There was a problem with ftplugin not loading when written in lua.
By adding an existing `hook_name starting with `lua_` to the condition,
Fixed so that the configuration as ftplugin is load.