### PR TITLE
Different comment symbols for lua_ in ftplugin

### DIFF
--- a/autoload/dein/parse.vim
+++ b/autoload/dein/parse.vim
@@ -417,12 +417,16 @@ function! s:generate_dummy_mappings(plugin) abort
   endfor
 endfunction
 function! s:merge_ftplugin(ftplugin) abort
-  const pattern = '\n\s*\\\|\%(^\|\n\)\s*"[^\n]*'
+  const pattern_vim = '\n\s*\\\|\%(^\|\n\)\s*"[^\n]*'
+  const pattern_lua = '\n\s*\\\|\%(^\|\n\)\s*--[^\n]*'
   for [ft, val] in a:ftplugin->items()
     if ft->stridx('lua_') == 0
+      let val = val->substitute(pattern_lua, '', 'g')
       " Convert lua_xxx keys
       let ft = ft->substitute('^lua_', '', '')
       let val = "lua <<EOF\n" .. val .. "\nEOF"
+    else
+      let val = val->substitute(pattern_vim, '', 'g')
     endif
 
     if !(g:dein#ftplugin->has_key(ft))
@@ -431,7 +435,6 @@ function! s:merge_ftplugin(ftplugin) abort
       let g:dein#ftplugin[ft] ..= "\n" .. val
     endif
   endfor
-  call map(g:dein#ftplugin, { _, val -> val->substitute(pattern, '', 'g') })
 endfunction
 
 function! dein#parse#_get_types() abort

--- a/test/parse.vim
+++ b/test/parse.vim
@@ -72,8 +72,12 @@ function! s:suite.load_toml() abort
 
     hook_add = "let g:foo = 0"
     [ftplugin]
-    c = "let g:bar = 0"
-    lua_d = "foo = 0"
+    c = """
+    let g:bar = 0
+    " Comment line"""
+    lua_d = """
+    foo = 0
+    -- Comment line"""
 
     [[plugins]]
     # repository name is required.


### PR DESCRIPTION
---
name: Bug Fixes
about: Fixing an problem with Dein.vim
title: ''
labels: ''
assignees: ''

---

## Bug Fixes

A clear and concise description of what the pull request does.

### Minimal Config

⚠️ Required when fixing bugs about plugins or the plugin manager.

See the minimal config example at [README#Config Example](https://github.com/Shougo/dein.vim#config-example), you can remove comments unrelated to the pull request.

```vim
" Add your minimal .vimrc or init.vim here.
" Example:
set runtimepath^=~/path/to/dein.nvim/
call dein#begin(path)
call dein#end()
```

## To Reproduce

Steps to reproduce the behavior:

1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

## Expected behavior

A clear and concise description of what you expected to happen.

## New Features

A clear and concise description about the features added by this PR.

- [...]

## Documentations

What documentation changes are required to clarify this?

## Checklist

- [ ] Have you added a description for why you want us to incorporate your changes and what they accomplish?
- [ ] Is there an issue for this PR right now? Link them at the bottom.
- [ ] The files have been linted and formatted, right?
- [ ] Have the docs been changed to reflect the PR's changes?
- [ ] Have the tests been revised to reflect the PR's changes?
- [ ] Have you locally performed the tests to ensure they pass?

## Additional context

Add any other context or help links about the problem here.

eg. Closes, Fix, or Resolves {issue/pull_request number}
