### PR TITLE
 Fixed a bug that caused incorrect parsing when an unrelated fold exists in a fold that represents a hook or ftplugin.

### DIFF
--- a/autoload/dein/parse.vim
+++ b/autoload/dein/parse.vim
@@ -530,9 +530,14 @@ function! dein#parse#_hooks_file(filename) abort
 
       let options[hook_name] = cur_lines->join("\n")
     else
+      if hook_name == ''
+        continue
+      endif
+
       if !(options->has_key('ftplugin'))
         let options['ftplugin'] = {}
       endif
+
       let options['ftplugin'][hook_name] = cur_lines->join("\n")
     endif
   endfor

--- a/autoload/dein/parse.vim
+++ b/autoload/dein/parse.vim
@@ -528,7 +528,11 @@ function! dein#parse#_hooks_file(filename) abort
           \ || hook_name->stridx('lua_done_') == 0
           \ || hook_name->stridx('lua_post_') == 0
 
-      let options[hook_name] = cur_lines->join("\n")
+      if !options->has_key(hook_name)
+        let options[hook_name] = ""
+      endif
+
+      let options[hook_name] ..= cur_lines->join("\n")
     else
       if hook_name == ''
         continue
@@ -538,7 +542,11 @@ function! dein#parse#_hooks_file(filename) abort
         let options['ftplugin'] = {}
       endif
 
-      let options['ftplugin'][hook_name] = cur_lines->join("\n")
+      if !(options.ftplugin->has_key(hook_name))
+        let options.ftplugin[hook_name] = ""
+      endif
+
+      let options['ftplugin'][hook_name] ..= cur_lines->join("\n")
     endif
   endfor
 

--- a/test/parse.vim
+++ b/test/parse.vim
@@ -292,10 +292,28 @@ function! s:suite.hooks_file() abort
     " hook_source {{{
     piyo
     }}}
-END
+  END
+
   call writefile(hooks_file, filename)
 
-  call s:assert.equals(dein#parse#_hooks_file(filename), {})
+  call s:assert.equals(dein#parse#_hooks_file(filename), #{
+        \   hook_source: 'piyo',
+        \ })
+
+  let hooks_file =<< trim END
+    " hook_source {{{
+    piyo
+    " {{{
+    hogera
+    " }}}
+    " }}}
+  END
+
+  call writefile(hooks_file, filename)
+
+  call s:assert.equals(dein#parse#_hooks_file(filename), #{
+        \   hook_source: "piyo\n" . '" {{{' . "\n" . 'hogera' . "\n" . '" }}}',
+        \ })
 
   let hooks_file =<< trim END
     -- lua_source {{{


### PR DESCRIPTION
fix #514 