### PR TITLE
Use g:dein#cache_directory and g:dein#runtime_directory

### DIFF
--- a/autoload/dein.vim
+++ b/autoload/dein.vim
@@ -61,7 +61,7 @@ function! dein#direct_install(repo, options = {}) abort
   call dein#install#_direct_install(a:repo, a:options)
 endfunction
 function! dein#get_direct_plugins_path() abort
-  return g:->get('dein#cache_directory', g:dein#_base_path)
+  return dein#util#_get_cache_path()
         \ .'/direct_install.vim'
 endfunction
 function! dein#reinstall(plugins) abort

--- a/autoload/dein/install.vim
+++ b/autoload/dein/install.vim
@@ -526,12 +526,12 @@ function! s:merge_files(plugins, directory) abort
   endfor
 
   if !(vimfiles->empty())
-    call dein#util#_cache_writefile(vimfiles,
-          \ printf('.dein/%s/%s.vim', a:directory, a:directory))
+    call dein#util#_safe_writefile(vimfiles,
+          \ dein#util#_get_runtime_path() . printf('/%s/%s.vim', a:directory, a:directory))
   endif
   if !(luafiles->empty())
-    call dein#util#_cache_writefile(luafiles,
-          \ printf('.dein/%s/%s.lua', a:directory, a:directory))
+    call dein#util#_safe_writefile(luafiles,
+          \ dein#util#_get_runtime_path() . printf('/%s/%s.lua', a:directory, a:directory))
   endif
 endfunction
 function! dein#install#_save_rollback(rollbackfile, plugins) abort

--- a/autoload/dein/min.vim
+++ b/autoload/dein/min.vim
@@ -68,8 +68,8 @@ END
 endfunction
 function! dein#min#_load_cache_raw(vimrcs) abort
   let g:dein#_vimrcs = a:vimrcs
-  const cache = g:->get('dein#cache_directory', g:dein#_base_path)
-        \ .. '/cache_' .. g:dein#_progname
+  const cache = dein#util#_get_cache_path()
+        \ .. '/cache_' .. g:dein#_progname .. '.json'
   const time = cache->getftime()
   if !(g:dein#_vimrcs->copy()
         \ ->map({ _, val -> getftime(expand(val)) })
@@ -86,7 +86,7 @@ function! dein#min#load_state(path) abort
   if g:dein#_is_sudo | return 1 | endif
   let g:dein#_base_path = a:path->expand()
 
-  const state = g:->get('dein#cache_directory', g:dein#_base_path)
+  const state = dein#util#_get_cache_path()
         \ .. '/state_' .. g:dein#_progname .. '.vim'
   if !(state->filereadable()) | return 1 | endif
   try

--- a/autoload/dein/util.vim
+++ b/autoload/dein/util.vim
@@ -27,7 +27,9 @@ function! dein#util#_get_runtime_path() abort
     return g:dein#_runtime_path
   endif
 
-  let g:dein#_runtime_path = dein#util#_get_cache_path() .. '/.dein'
+  let g:dein#_runtime_path = dein#util#_substitute_path(
+        \ g:->get('dein#runtime_directory', dein#util#_get_cache_path()
+        \ .. '/.dein/'))
   call dein#util#_safe_mkdir(g:dein#_runtime_path)
   return g:dein#_runtime_path
 endfunction
@@ -40,8 +42,8 @@ function! dein#util#_get_cache_path() abort
         \ $NVIM_APPNAME :
         \ dein#util#_get_myvimrc()->fnamemodify(':t')
   let g:dein#_cache_path = dein#util#_substitute_path(
-        \ g:->get('dein#cache_directory', g:dein#_base_path)
-        \ .. '/.cache/' .. vimrc_path)
+        \ g:->get('dein#cache_directory', g:dein#_base_path
+        \ .. '/.cache/' .. vimrc_path))
   call dein#util#_safe_mkdir(g:dein#_cache_path)
   return g:dein#_cache_path
 endfunction
@@ -163,14 +165,6 @@ function! dein#util#_check_clean() abort
         \ })
 endfunction
 
-function! dein#util#_cache_writefile(list, path) abort
-  if !(dein#util#_get_cache_path()->filewritable())
-    return 1
-  endif
-
-  const path = dein#util#_get_cache_path() .. '/' .. a:path
-  return dein#util#_safe_writefile(a:list, path)
-endfunction
 function! dein#util#_safe_writefile(list, path, flags = '') abort
   if g:dein#_is_sudo
     return 1
@@ -232,8 +226,8 @@ function! dein#util#_save_cache(vimrcs, is_state, is_starting) abort
   const src = [plugins, g:dein#ftplugin]
   call dein#util#_safe_writefile(
         \ has('nvim') ? [src->json_encode()] : [src->js_encode()],
-        \ g:->get('dein#cache_directory', g:dein#_base_path)
-        \ .. '/cache_' .. g:dein#_progname)
+        \ dein#util#_get_cache_path()
+        \ .. '/cache_' .. g:dein#_progname .. '.json')
 endfunction
 function! dein#util#_check_vimrcs() abort
   const time = dein#util#_get_runtime_path()->getftime()
@@ -379,12 +373,12 @@ function! dein#util#_save_state(is_starting) abort
           \ event, plugins->string()))
   endfor
 
-  const state = g:->get('dein#cache_directory', g:dein#_base_path)
+  const state = dein#util#_get_cache_path()
         \ .. '/state_' .. g:dein#_progname .. '.vim'
   call dein#util#_safe_writefile(lines, state)
 endfunction
 function! dein#util#_clear_state() abort
-  const base = g:->get('dein#cache_directory', g:dein#_base_path)
+  const base = dein#util#_get_cache_path()
   for cache in (base .. '/state_*.vim')->glob(v:true, v:true)
         \ + (base .. '/cache_*')->glob(v:true, v:true)
     call delete(cache)

--- a/doc/dein.txt
+++ b/doc/dein.txt
@@ -517,6 +517,13 @@ g:dein#cache_directory
 		Default: Under the base directory you have already specified
 		by |dein#begin()|.
 
+                                                      *g:dein#runtime_directory*
+g:dein#runtime_directory
+		The runtime directory to use. Contains all merged files.
+		See |dein-merge| notes.
+
+		Default: |g:dein#cache_directory| . '/.dein'
+
                                                       *g:dein#default_options*
 g:dein#default_options
 		The default options for plugins.


### PR DESCRIPTION
# Description

g:dein#cache_directory is only used in dein#util#_get_cache_path()
g:dein#runtime_directory is only used in dein#util#_get_runtime_path()

Rename cache_{g:dein#_progname} to cache_{g:dein#_progname}.json
because it is really a json

Use dein#util#_get_cache_path() to store:

- cache_{g:dein#_progname}.json
- state_{g:dein#_progname}.vim
- direct_install.vim
- rollbacks/{g:dein#_progname}/

Use dein#util#_get_runtime_path() to store the merged vim files

Be default, it is dein#util#_get_cache_path() . '/.dein'
in order to keep same behavior

Remove dein#util#_cache_writefile() because it is not used again
