### PR TITLE
Remove unnecessary trailing path separator

### DIFF
--- a/autoload/dein/util.vim
+++ b/autoload/dein/util.vim
@@ -29,7 +29,7 @@ function! dein#util#_get_runtime_path() abort
 
   let g:dein#_runtime_path = dein#util#_substitute_path(
         \ g:->get('dein#runtime_directory', dein#util#_get_cache_path()
-        \ .. '/.dein/'))
+        \ .. '/.dein'))
   call dein#util#_safe_mkdir(g:dein#_runtime_path)
   return g:dein#_runtime_path
 endfunction


### PR DESCRIPTION
This PR addresses an issue introduced in PR #517, where a `/` was appended to the end of the return value of `dein#util#_get_runtime_path()`. This change caused some plugins loaded with `dein#load_toml(s:toml, #{ lazy: 1 })` to stop functioning properly. This PR provides a fix for the issue.